### PR TITLE
Filter evaluation&dataset class change

### DIFF
--- a/TestRunner.py
+++ b/TestRunner.py
@@ -96,24 +96,24 @@ class TransformationRuns(object):
 
 class FilterRuns(object):
 
-    def __init__(self):
+    def __init__(self, name_of_filter):
         filters = []
         filter_test_cases = []
         package_dir = Path(__file__).resolve()  # --> TestRunner.py
-        filters_dir = package_dir.parent.joinpath("filters")
-        for (_, m, _) in iter_modules([filters_dir]):
-            t_py = import_module(f"filters.{m}")
-            t_js = os.path.join(filters_dir, m, "test.json")
+        filters_dir = package_dir.parent.joinpath("filters", name_of_filter)
+        
+        t_py = import_module(f"filters.{name_of_filter}")
+        t_js = os.path.join(filters_dir, "test.json")
 
-            for test_case in load_test_cases(t_js):
-                class_name = test_case["class"]
-                class_args = test_case["args"]
-                # construct filter class with input args
-                cls = getattr(t_py, class_name)
-                filter_instance = cls(**class_args)
+        for test_case in load_test_cases(t_js):
+            class_name = test_case["class"]
+            class_args = test_case["args"]
+            # construct filter class with input args
+            cls = getattr(t_py, class_name)
+            filter_instance = cls(**class_args)
 
-                filters.append(filter_instance)
-                filter_test_cases.append(test_case)
+            filters.append(filter_instance)
+            filter_test_cases.append(test_case)
 
         self.filters = filters
         self.filter_test_cases = filter_test_cases

--- a/dataset.py
+++ b/dataset.py
@@ -8,27 +8,27 @@ from interfaces.QuestionAnswerOperation import QuestionAnswerOperation
 from tasks.TaskTypes import TaskType
 
 
-class BaseDataset(object):
-    
+class BaseDataset(Iterable):
+
     def __init__(self, data: Iterable):
         self.data = data
-    
+
     def apply_filter(self, condition: Operation):
         raise NotImplementedError(
             "BaseDataset does not implement this function.")
-        
+
     def apply_transformation(self, transformation: Operation):
         raise NotImplementedError(
             "BaseDataset does not implement this function.")
-        
-    def _get_text(self, data_row):
+
+    def __iter__(self):
         raise NotImplementedError(
             "BaseDataset does not implement this function.")
-        
+
     def __len__(self):
         raise NotImplementedError(
             "BaseDataset does not implement this function.")
-    
+
     def __or__(self, other):
         raise NotImplementedError(
             "BaseDataset does not implement this function.")
@@ -36,25 +36,37 @@ class BaseDataset(object):
     def __and__(self, other):
         raise NotImplementedError(
             "BaseDataset does not implement this function.")
-    
+
     def __sub__(self, other):
         raise NotImplementedError(
             "BaseDataset does not implement this function")
 
+
 '''
 Dataset for data in plain texts where each line is a datapoint
 '''
+
+
 class TextLineDataset(BaseDataset):
     tasks = [TaskType.TEXT_CLASSIFICATION]
-    
+
     def __init__(self, data: List[str], labels: List):
         super(TextLineDataset, self).__init__(data)
         assert len(data) == len(
             labels), "The number of datapoint should be the same as the number of labels"
         self.labels = labels
-        self.mapping = {datapoint:label
+        self.mapping = {datapoint: label
                         for datapoint, label in zip(self.data, self.labels)}
         
+    @classmethod
+    def from_huggingface(cls, dataset, fields):
+        data = []
+        labels = []
+        for example in dataset:
+            data.append(example[fields[0]])
+            labels.append(example[fields[1]])
+        return cls(data, labels)
+
     def apply_filter(self, filter: SentenceOperation) -> TextLineDataset:
         filtered_data = []
         filtered_labels = []
@@ -63,7 +75,7 @@ class TextLineDataset(BaseDataset):
             if filter.filter(datapoint):
                 filtered_data.append(datapoint)
                 filtered_labels.append(label)
-        
+
         return TextLineDataset(filtered_data, filtered_labels)
 
     def apply_transformation(self, transformation: SentenceOperation) -> TextLineDataset:
@@ -71,12 +83,16 @@ class TextLineDataset(BaseDataset):
         print("Applying transformation:")
         for line in tqdm(self.data):
             transformed_data.append(transformation.generate(line))
-        
+
         return TextLineDataset(transformed_data, self.labels)
-    
+
+    def __iter__(self):
+        for text, label in zip(self.data, self.labels):
+            yield (text, label)
+
     def __len__(self):
         return len(self.data)
-        
+
     def __or__(self, other: TextLineDataset) -> TextLineDataset:
         data = list(set(self.data).union(set(other.data)))
         mapping = {**self.mapping, **other.mapping}
@@ -97,6 +113,8 @@ class TextLineDataset(BaseDataset):
 '''
 Dataset for data in format of key-value pairs, e.g. data read from jsonl file
 '''
+
+
 class KeyValueDataset(BaseDataset):
     tasks = [TaskType.TEXT_TO_TEXT_GENERATION,
              TaskType.QUESTION_ANSWERING,
@@ -106,54 +124,85 @@ class KeyValueDataset(BaseDataset):
     # task_type: task type specified
     # fields: list of relavent keys (e.g. to your sentence/target, context/question/answer, etc.)
     #         The number of keys should be aligned with the transform/filter operation.
-    def __init__(self, data: List[dict], task_type=TaskType.TEXT_TO_TEXT_GENERATION, fields: List[str]=None):
+    def __init__(self, data: List[dict], task_type=TaskType.TEXT_TO_TEXT_GENERATION, fields: List[str] = None):
         super(KeyValueDataset, self).__init__(data)
         self.task_type = task_type
         self.fields = fields
         self.operation_type = None
-        
-        if self.task_type == TaskType.TEXT_TO_TEXT_GENERATION:
-            if len(self.fields) == 2:
-                # assume two keys for SentenceAndTargetOperation, the two keys should refer to the "sentence" and "target"
-                self.operation_type = "sentence_and_target"
-            elif len(self.fields) > 2:
-                # assume more than two keys for SentenceAndTargetsOperation, the first key refer to "sentence", others refer to "targets"
-                self.operation_type = "sentence_and_targets"
-        elif self.task_type in [TaskType.QUESTION_ANSWERING, TaskType.QUESTION_GENERATION]:
-            self.operation_type = "question_answer"
-            
-        self.filter_func = self.__getattribute__(
-            "_apply_" + self.operation_type + "_filter")
-        self.transformation_func = self.__getattribute__(
-            "_apply_" + self.operation_type + "_transformation")
-    
+
     @classmethod
     def from_huggingface(cls, dataset, task_type, fields):
         data = []
-        for example in dataset:
-            data.append({key:example[key] for key in fields})
+        if task_type not in [TaskType.QUESTION_ANSWERING, TaskType.QUESTION_GENERATION]:
+            for example in dataset:
+                data.append({key: example[key] for key in fields})
+        else:
+            # this is an ugly implementation, which hard-codes the squad data format
+            # TODO might need a more elegant way to deal with the fields with hierachy, e.g. the answers field in squad data (exampl['answers']['text'])
+            for example in dataset:
+                data.append({
+                    fields[0]: example[fields[0]],
+                    fields[1]: example[fields[1]],
+                    fields[2]: example[fields[2]]['text'],
+                })
         return cls(data, task_type, fields)
 
+    def _analyze(self, subfields: List[str]):
+        if subfields is None:
+            subfields = self.fields
+            
+        assert set(subfields) <= set(
+            self.fields), "Your can only choose from fields within {}".format(self.fields)
+
+        if self.task_type == TaskType.TEXT_TO_TEXT_GENERATION:
+            if len(subfields) == 1:
+                self.operation_type = "sentence"
+            elif len(subfields) == 2:
+                self.operation_type = "sentence_and_target"
+            elif len(subfields) > 2:
+                self.operation_type = "sentence_and_targets"
+        elif self.task_type in [TaskType.QUESTION_ANSWERING, TaskType.QUESTION_GENERATION]:
+            # this is in case that one would like to use SentenceOperation (e.g. butter finger) on specific fields (e.g. only the question)
+            if len(subfields) == 1:
+                self.operation_type = "sentence"
+            elif len(subfields) == 2:
+                self.operation_type = "sentence_and_target"
+            else:
+                self.operation_type = "question_answer"
+
+        filter_func = self.__getattribute__(
+            "_apply_" + self.operation_type + "_filter")
+        transformation_func = self.__getattribute__(
+            "_apply_" + self.operation_type + "_transformation")
+        return filter_func, transformation_func
+
     # this function is an adapter and will call the corresponding filter function for the task
-    def apply_filter(self, filter: Operation) -> KeyValueDataset:
+    # subfields: the fields to apply filter, it is a subset of self.fields
+    def apply_filter(self, filter: Operation, subfields: List[str] = None) -> KeyValueDataset:
+        filter_func, _ = self._analyze(subfields)
+        
         filtered_data = []
         print("Applying filtering:")
         for datapoint in tqdm(self.data):
-            if self.filter_func(datapoint, filter):
+            if filter_func(datapoint, filter):
                 filtered_data.append(datapoint)
-        
+
         return KeyValueDataset(filtered_data, self.task_type, self.fields)
     
+    def _apply_sentence_filter(self, datapoint: dict, filter: SentenceOperation):
+        sentence = datapoint[self.fields[0]]
+        return filter.filter(sentence)
+
     def _apply_sentence_and_target_filter(self, datapoint: dict, filter: SentenceAndTargetOperation):
         sentence = datapoint[self.fields[0]]
         target = datapoint[self.fields[1]]
         return filter.filter(sentence, target)
-    
+
     def _apply_sentence_and_targets_filter(self, datapoint: dict, filter: SentenceAndTargetsOperation):
         sentence = datapoint[self.fields[0]]
         targets = [datapoint[target_key] for target_key in self.fields[1:]]
         return filter.filter(sentence, targets)
-    
+
     def _apply_question_answer_filter(self, datapoint: dict, filter: QuestionAnswerOperation):
         context = datapoint[self.fields[0]]
         question = datapoint[self.fields[1]]
@@ -161,18 +210,28 @@ class KeyValueDataset(BaseDataset):
         return filter.filter(context, question, answers)
 
     # this function is an adapter and will call the corresponding transform function for the task
-    def apply_transformation(self, transformation: Operation) -> KeyValueDataset:
+    # subfields: the fields to apply transformation, it is a subset of self.fields
+    def apply_transformation(self, transformation: Operation, subfields: List[str] = None) -> KeyValueDataset:
+        _, transformation_func = self._analyze(subfields)
         transformed_data = []
         print("Applying transformation:")
         for datapoint in tqdm(self.data):
-            transformed_data.append(self.transformation_func(datapoint, transformation))
-        
+            transformed_data.append(
+                transformation_func(datapoint.copy(), transformation)) # don't want self.data to be changed
+
         return KeyValueDataset(transformed_data, self.task_type, self.fields)
     
+    def _apply_sentence_transformation(self, datapoint: dict, transformation: SentenceOperation):
+        sentence = datapoint[self.fields[0]]
+        transformed_sentence = transformation.generate(sentence)
+        datapoint[self.fields[0]] = transformed_sentence
+        return datapoint
+
     def _apply_sentence_and_target_transformation(self, datapoint: dict, transformation: SentenceAndTargetOperation):
         sentence = datapoint[self.fields[0]]
         target = datapoint[self.fields[1]]
-        transformed_sentence, transformed_target = transformation.generate(sentence, target)
+        transformed_sentence, transformed_target = transformation.generate(
+            sentence, target)
         datapoint[self.fields[0]] = transformed_sentence
         datapoint[self.fields[1]] = transformed_target
         return datapoint
@@ -182,33 +241,40 @@ class KeyValueDataset(BaseDataset):
         targets = [datapoint[target_key] for target_key in self.fields[1:]]
         transformed_sentence, transformed_targets = transformation.generate(
             sentence, targets)
-        
+
         datapoint[self.fields[0]] = transformed_sentence
         for i, target_key in enumerate(self.fields[1:]):
             datapoint[target_key] = transformed_targets[i]
-            
+
         return datapoint
 
     def _apply_question_answer_transformation(self, datapoint: dict, transformation: QuestionAnswerOperation):
         context = datapoint[self.fields[0]]
         question = datapoint[self.fields[1]]
         answers = [datapoint[answer_key] for answer_key in self.fields[2:]]
-        transformed_context, transformed_question, transformed_answers = transformation.generate(context, question, answers)
-        
+        transformed_context, transformed_question, transformed_answers = transformation.generate(
+            context, question, answers)
+
         datapoint[self.fields[0]] = transformed_context
         datapoint[self.fields[1]] = transformed_question
         for i, answers_key in enumerate(self.fields[2:]):
             datapoint[answers_key] = transformed_answers[i]
-            
+
         return datapoint
+
+    def __iter__(self):
+        for datapoint in self.data:
+            yield (datapoint[field] for field in self.fields)
 
     def __len__(self):
         return len(self.data)
 
     def _sanity_check(self, other: BaseDataset):
-        assert self.data[0].keys() == other.data[0].keys(), "You cannot do dataset operation on datasets with different keys"
+        assert self.data[0].keys() == other.data[0].keys(
+        ), "You cannot do dataset operation on datasets with different keys"
         assert self.task_type == other.task_type, "You cannot do dataset operation on datasets for different tasks"
-        assert len(self.fields) == len(other.fields), "You cannot do dataset operation on datasets with different number fields"
+        assert len(self.fields) == len(
+            other.fields), "You cannot do dataset operation on datasets with different number fields"
 
     def _data2identifier(self, data: List[str]):
         id2datapoint = {}
@@ -223,7 +289,7 @@ class KeyValueDataset(BaseDataset):
             identifier2id[identifier] = idx
         identifiers = set(identifiers)  # remove duplicates
         return id2datapoint, identifier2id, identifiers
-    
+
     def _identifier2data(self, id2datapoint, identifier2id, identifiers):
         result_data = []
         for identifier in identifiers:
@@ -232,24 +298,27 @@ class KeyValueDataset(BaseDataset):
 
     def __or__(self, other: KeyValueDataset) -> KeyValueDataset:
         self._sanity_check(other)
-        id2datapoint, identifier2id, identifiers = self._data2identifier(self.data+other.data)
+        id2datapoint, identifier2id, identifiers = self._data2identifier(
+            self.data+other.data)
         data = self._identifier2data(id2datapoint, identifier2id, identifiers)
         return KeyValueDataset(data, self.task_type, self.fields)
-            
+
     def __and__(self, other: KeyValueDataset) -> KeyValueDataset:
         self._sanity_check(other)
-        id2datapoint, identifier2id, identifiers = self._data2identifier(self.data)
+        id2datapoint, identifier2id, identifiers = self._data2identifier(
+            self.data)
         _, _, identifiers2 = self._data2identifier(other.data)
-        
+
         identifiers = identifiers.intersection(identifiers2)
         data = self._identifier2data(id2datapoint, identifier2id, identifiers)
         return KeyValueDataset(data, self.task_type, self.fields)
 
     def __sub__(self, other: KeyValueDataset) -> KeyValueDataset:
         self._sanity_check(other)
-        id2datapoint, identifier2id, identifiers = self._data2identifier(self.data)
+        id2datapoint, identifier2id, identifiers = self._data2identifier(
+            self.data)
         _, _, identifiers2 = self._data2identifier(other.data)
-        
+
         identifiers = identifiers.difference(identifiers2)
         data = self._identifier2data(id2datapoint, identifier2id, identifiers)
         return KeyValueDataset(data, self.task_type, self.fields)

--- a/filters/README.md
+++ b/filters/README.md
@@ -35,10 +35,10 @@ class CustomFilter(Interface):
                 "arg1": ...,
                 "arg2": ...
             },
-            "filter_args": {
+            "inputs": {
                 "sentence": ...
             },
-            "output": true
+            "outputs": true
         }
     ]
 }

--- a/filters/keywords/test.json
+++ b/filters/keywords/test.json
@@ -6,10 +6,10 @@
             "args": {
                 "keywords": ["in", "at"]
             },
-            "filter_args": {
+            "inputs": {
                 "sentence": "Andrew played cricket in India"
             },
-            "output": true
+            "outputs": true
         }
     ]
 }

--- a/filters/length/test.json
+++ b/filters/length/test.json
@@ -7,10 +7,10 @@
                 "op": ">",
                 "threshold": 3
             },
-            "filter_args": {
+            "inputs": {
                 "sentence": "Andrew played cricket in India"
             },
-            "output": true
+            "outputs": true
         },
         {
             "class": "SentenceAndTargetLengthFilter",
@@ -18,11 +18,11 @@
                 "ops": [">", "<"],
                 "thresholds": [3, 10]
             },
-            "filter_args": {
+            "inputs": {
                 "sentence": "Andrew played cricket in India",
                 "target": "Andrew finally returned the French book to Chris that I bought last week."
             },
-            "output": false
+            "outputs": false
         }
     ]
 }

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,13 @@
 def pytest_addoption(parser):
     parser.addoption("--t", action="store", default="butter_fingers_perturbation")
+    parser.addoption("--f", action="store", default="length")
 
 
 def pytest_generate_tests(metafunc):
     option_value = metafunc.config.option.t
     if "transformation_name" in metafunc.fixturenames and option_value is not None:
         metafunc.parametrize("transformation_name", [option_value])
+
+    option_value = metafunc.config.option.f
+    if "filter_name" in metafunc.fixturenames and option_value is not None:
+        metafunc.parametrize("filter_name", [option_value])

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -108,9 +108,9 @@ def execute_test_case_for_transformation(transformation_name):
 def test_filter(filter_name):
     tx = FilterRuns(filter_name)
     for filter, test in zip(tx.filters, tx.filter_test_cases):
-        filter_args = test["filter_args"]
+        filter_args = test["inputs"]
         output = filter.filter(**filter_args)
-        assert output == test["output"], f"The filter should return {test['output']}"
+        assert output == test["outputs"], f"The filter should return {test['outputs']}"
 
 
 def main():

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -105,8 +105,8 @@ def execute_test_case_for_transformation(transformation_name):
         execute_tagging_test_case(impl)
 
 
-def test_execute_filter_test_case():
-    tx = FilterRuns()
+def test_filter(filter_name):
+    tx = FilterRuns(filter_name)
     for filter, test in zip(tx.filters, tx.filter_test_cases):
         filter_args = test["filter_args"]
         output = filter.filter(**filter_args)


### PR DESCRIPTION
- modifying filter testcase, now can specify which filter to test with pytest option
- changing the name convention of "test.json", changing from "filter_args" to "inputs"
- adding labels into TextLineDataset, all dataset-level operation will change labels as well
- changing the return type of several functions in dataset classes (before was returning data, now returning a new dataset class instance)
- integrating dataset class into the evaluation flow, adding classmethods to construct dataset from huggingface dataset. Such encapsulation might be helpful when we what to evaluation dataset-level operations (e.g. contrast sets) in the future implementations.
- Updating the calculation of BLEU from averaging sentence bleu to corpus bleu. Averaging sentence bleu is not commonly used, see [here](https://github.com/mjpost/sacrebleu/blob/e22640/sacrebleu/compat.py#L66-L67).