### PR TITLE
bug fix: TypeError - string indices must be integers

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -246,7 +246,7 @@ class KeyValueDataset(BaseDataset):
         sentence = datapoint[self.fields[0]]
         transformed_sentence = transformation.generate(sentence)
         datapoint[self.fields[0]] = transformed_sentence
-        return datapoint
+        return [datapoint]
 
     def _apply_sentence_and_target_transformation(
             self, datapoint: dict, transformation: SentenceAndTargetOperation
@@ -258,7 +258,7 @@ class KeyValueDataset(BaseDataset):
         )
         datapoint[self.fields[0]] = transformed_sentence
         datapoint[self.fields[1]] = transformed_target
-        return datapoint
+        return [datapoint]
 
     def _apply_sentence_and_targets_transformation(
             self, datapoint: dict, transformation: SentenceAndTargetsOperation
@@ -273,7 +273,7 @@ class KeyValueDataset(BaseDataset):
             datapoint_n = dict()
             datapoint_n[self.fields[0]] = to[0]
             for i, target_key in enumerate(self.fields[1:]):
-                datapoint[target_key] = to[1][i]
+                datapoint[target_key] = to[1][1+i] # targets starting from pos 1
             datapoints.append(datapoint_n)
         return datapoints
 
@@ -291,7 +291,7 @@ class KeyValueDataset(BaseDataset):
             datapoint_n[self.fields[0]] = to[0]
             datapoint_n[self.fields[1]] = to[1]
             for i, answers_key in enumerate(self.fields[2:]):
-                datapoint_n[answers_key] = to[i]
+                datapoint_n[answers_key] = to[2+i] # answers starting from pos 2
             datapoints.append(datapoint_n)
 
         return datapoints


### PR DESCRIPTION
Fixing the bug when running `python evaluate.py -t ButterFingersPerturbation -task "TEXT_TO_TEXT_GENERATION" -p 1` as mentioned in #78 
```
Traceback (most recent call last):
  File "evaluate.py", line 67, in <module>
    if_filter
  File "./NL-Augmenter/evaluation/evaluation_engine.py", line 41, in evaluate
    percentage_of_examples=percentage_of_examples,
  File "./NL-Augmenter/evaluation/evaluation_engine.py", line 115, in execute_model
    split=f"test[:{percentage_of_examples}%]",
  File "./NL-Augmenter/evaluation/evaluate_text_generation.py", line 44, in evaluate
    dataset, summarization_pipeline, transformation=operation
  File "./NL-Augmenter/evaluation/evaluate_text_generation.py", line 70, in transformation_performance
    pt_dataset, summarization_pipeline
  File "./NL-Augmenter/evaluation/evaluate_text_generation.py", line 81, in performance_on_dataset
    article, gold_summary = example
  File "./NL-Augmenter/dataset.py", line 301, in <genexpr>
    yield (datapoint[field] for field in self.fields)
TypeError: string indices must be integers
```