### PR TITLE
Update license requirements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ We also accept pull-requests for creating [filters](filters) which identify inte
 After all pull-requests have been merged, 3 of the [most creative implementations](docs/doc.md#Three-most-creative-Implementations) would be selected and featured on this README page and on the NL-Augmenter [webpage](https://gem-benchmark.com/nl_augmenter).
 
 ### License
-Some transformations use a separate license. For full license details, refer to the license file in the transformations's/filter's directory.
+Some transformations include components released under a different (permissive, open source) license. For license details, refer to the `README.md` and any license files in the transformations's or filter's directory.

--- a/README.md
+++ b/README.md
@@ -114,3 +114,6 @@ We also accept pull-requests for creating [filters](filters) which identify inte
 ### Most Creative Implementations 🏆
 
 After all pull-requests have been merged, 3 of the [most creative implementations](docs/doc.md#Three-most-creative-Implementations) would be selected and featured on this README page and on the NL-Augmenter [webpage](https://gem-benchmark.com/nl_augmenter).
+
+### License 🏆
+Some transformations use a separate license. For full license details, refer to the license file in the transformations's/filter's directory.

--- a/README.md
+++ b/README.md
@@ -115,5 +115,5 @@ We also accept pull-requests for creating [filters](filters) which identify inte
 
 After all pull-requests have been merged, 3 of the [most creative implementations](docs/doc.md#Three-most-creative-Implementations) would be selected and featured on this README page and on the NL-Augmenter [webpage](https://gem-benchmark.com/nl_augmenter).
 
-### License 🏆
+### License
 Some transformations use a separate license. For full license details, refer to the license file in the transformations's/filter's directory.

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -50,6 +50,8 @@ class ButterFingersPerturbation(SentenceOperation):
 
 **Description:** The `README.md` file should clearly explain what the transformation is attempting to generate as well as the importance of that transformation for the specified tasks.
 
+**Data and code source:** The `README.md` file should have a subsection titled "Data and code provenance", which should describe where data or code came from, or that it was fully created by the author. This section should also disclose the license that any external data or code is released under.
+
 **Paraphrasers and Data Augmenters:** Besides perturbations, we welcome transformation methods that act like paraphrasers and data augmenters. For non-deterministic approaches, we encourage you to specify metrics which can provide an estimate of the generation quality. We prefer high precision transformation generators over low accuracy ones. And hence it's okay if your transformation selectively generates. If your transformation loads a deep-learning model, especially a heavy one (like BERT or T5 etc.), set the `heavy` parameter to `True`.
  
 **Test Cases:** We recommend you to add 5 examples in the file `test.json` as test cases for every added transformation. These examples serve as test cases and provide reviewers a sample of your transformation's output. The format of `test.json` can be borrowed from the sample transformations [here.](../interfaces) Addition of the the test cases is **not mandatory** but is encouraged.

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -45,7 +45,8 @@ class ButterFingersPerturbation(SentenceOperation):
 
 **Novelty:** Your transformation must improve the coverage of NL-Augmenter in a meaningful way. The idea behind your transformation need not be novel, but its contribution to the library must be different from the contributions of earlier submissions. If you are unsure if your idea would constitute a new contribution, please email the organizers at nl-augmenter@googlegroups.com and we are happy to help.
 
-**Adding New Libraries:** We welcome addition of libraries which are light and can be installed via `pip`. Every library should specify the version number associated and be added in a new [requirements.txt](../transformations/punctuation) in the transformation's own folder. However, we discourage the use of heavy libraries for a few lines of code which could be manually written instead. Please ensure that all the libraries have either Apache 2 or MIT License. If not, you need to add the correct license file into the transformation/filer folder too. 
+**Adding New Libraries:** We welcome addition of libraries which are light and can be installed via `pip`. Every library should specify the version number associated and be added in a new [requirements.txt](../transformations/punctuation) in the transformation's own folder. However, we discourage the use of heavy libraries for a few lines of code which could be manually written instead. Please ensure that all the libraries have either Apache 2, MIT License **or a similar license** like BSD. For a different license like BSD, you would need to add the appropriate license file into your transformation/filter folder too. If you are unsure, please email the organizers at nl-augmenter@googlegroups.com. 
+
 
 **Description:** The `README.md` file should clearly explain what the transformation is attempting to generate as well as the importance of that transformation for the specified tasks.
 

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -45,7 +45,7 @@ class ButterFingersPerturbation(SentenceOperation):
 
 **Novelty:** Your transformation must improve the coverage of NL-Augmenter in a meaningful way. The idea behind your transformation need not be novel, but its contribution to the library must be different from the contributions of earlier submissions. If you are unsure if your idea would constitute a new contribution, please email the organizers at nl-augmenter@googlegroups.com and we are happy to help.
 
-**Adding New Libraries:** We welcome addition of libraries which are light and can be installed via `pip`. Every library should specify the version number associated and be added in a new [requirements.txt](../transformations/punctuation) in the transformation's own folder. However, we discourage the use of heavy libraries for a few lines of code which could be manually written instead. Please ensure that the libraries have either Apache 2 or MIT License. 
+**Adding New Libraries:** We welcome addition of libraries which are light and can be installed via `pip`. Every library should specify the version number associated and be added in a new [requirements.txt](../transformations/punctuation) in the transformation's own folder. However, we discourage the use of heavy libraries for a few lines of code which could be manually written instead. Please ensure that all the libraries have either Apache 2 or MIT License. If not, you need to add the correct license file into the transformation/filer folder too. 
 
 **Description:** The `README.md` file should clearly explain what the transformation is attempting to generate as well as the importance of that transformation for the specified tasks.
 

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -45,7 +45,7 @@ class ButterFingersPerturbation(SentenceOperation):
 
 **Novelty:** Your transformation must improve the coverage of NL-Augmenter in a meaningful way. The idea behind your transformation need not be novel, but its contribution to the library must be different from the contributions of earlier submissions. If you are unsure if your idea would constitute a new contribution, please email the organizers at nl-augmenter@googlegroups.com and we are happy to help.
 
-**Adding New Libraries:** We welcome addition of libraries which are light and can be installed via `pip`. Every library should specify the version number associated and be added in a new [requirements.txt](../transformations/punctuation) in the transformation's own folder. However, we discourage the use of heavy libraries for a few lines of code which could be manually written instead. Please ensure that all the libraries have either Apache 2, MIT License **or a similar license** like BSD. For a different license like BSD, you would need to add the appropriate license file into your transformation/filter folder too. If you are unsure, please email the organizers at nl-augmenter@googlegroups.com. 
+**Adding New Libraries:** We welcome addition of libraries which are light and can be installed via `pip`. Every library should specify the version number associated and be added in a new [requirements.txt](../transformations/punctuation) in the transformation's own folder. However, we discourage the use of heavy libraries for a few lines of code which could be manually written instead. Please ensure that all libraries have MIT, Apache 2, BSD, or other permissive license. GPL-licensed libraries are not approved for NL-Augmenter. If you are unsure, please email the organizers at nl-augmenter@googlegroups.com. 
 
 
 **Description:** The `README.md` file should clearly explain what the transformation is attempting to generate as well as the importance of that transformation for the specified tasks.
@@ -76,4 +76,3 @@ The `test.json` simply serves to keep track of the core logic of transformation 
 
 ## Three Most Creative Implementations
  🏆  🏆  🏆 After all pull-requests have been merged, 3 of the most creative implementations would be selected and featured on this README page. The selection would be done by the [organizers of NL-Augmenter](https://gem-benchmark.com/nl_augmenter). The minimum requirement to be featured as "most creative" is novelty of implementation i.e. must be the participant's own work.
-


### PR DESCRIPTION
Every transformation/filter should include a license file if they use a library which do not have an MIT or Apace2 license.