### PR TITLE
Adding rate of successful transformation in dataset

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -100,8 +100,32 @@ class TextLineDataset(BaseDataset):
     ) -> TextLineDataset:
         transformed_data = []
         print("Applying transformation:")
+
+        # calculating ratio of transformed example to unchanged example
+        successful_num = 0
+        failed_num = 0
+
         for line in tqdm(self.data):
-            transformed_data.extend(transformation.generate(line))
+            pt_examples = transformation.generate(line)
+            successful_pt, failed_pt = transformation.compare(
+                line, pt_examples
+            )
+            successful_num += successful_pt
+            failed_num += failed_pt
+
+            transformed_data.extend(pt_examples)
+
+        total_num = successful_num + failed_num
+
+        print(
+            "Finished transformation! {} examples generated from {} original examples, with {} successfully transformed and {} unchanged ({} perturb rate)".format(
+                total_num,
+                len(self.data),
+                successful_num,
+                failed_num,
+                successful_num / total_num,
+            )
+        )
 
         return TextLineDataset(transformed_data, self.labels)
 
@@ -264,10 +288,32 @@ class KeyValueDataset(BaseDataset):
         _, transformation_func = self._analyze(subfields)
         transformed_data = []
         print("Applying transformation:")
+        
+        # calculating ratio of transformed example to unchanged example
+        successful_num = 0
+        failed_num = 0
+        
         for datapoint in tqdm(self.data):
-            transformed_data.extend(
-                transformation_func(datapoint.copy(), transformation)
-            )  # don't want self.data to be changed
+            pt_examples = transformation_func(datapoint.copy(), transformation)
+            successful_pt, failed_pt = transformation.compare(
+                datapoint, pt_examples
+            )
+            successful_num += successful_pt
+            failed_num += failed_pt
+            
+            transformed_data.extend(pt_examples)  # don't want self.data to be changed
+        
+        total_num = successful_num + failed_num
+
+        print(
+            "Finished transformation! {} examples generated from {} original examples, with {} successfully transformed and {} unchanged ({} perturb rate)".format(
+                total_num,
+                len(self.data),
+                successful_num,
+                failed_num,
+                successful_num / total_num,
+            )
+        )
 
         return KeyValueDataset(transformed_data, self.task_type, self.fields)
 

--- a/interfaces/Operation.py
+++ b/interfaces/Operation.py
@@ -1,3 +1,4 @@
+from typing import Tuple, List
 """Generic operation class. """
 
 
@@ -14,6 +15,17 @@ class Operation(object):
         self.max_outputs = max_outputs
         if self.verbose:
             print(f"Loading Operation {self.name()}")
+            
+    @classmethod
+    def compare(self, raw: object, pt: List[object]) -> Tuple[int, int]:
+        successful_pt = 0
+        failed_pt = 0
+        for pt_example in pt:
+            if pt_example == raw:
+                failed_pt += 1
+            else:
+                successful_pt += 1
+        return successful_pt, failed_pt
 
     @classmethod
     def is_heavy(cls):


### PR DESCRIPTION
Adding information on the rate of successful transformation. This might indicate the coverage of a specific transformation during evaluation because some transformations only apply to specific patterns of texts.