### PR TITLE
Sentence Addition Transformation

### DIFF
--- a/transformations/sentence_additions/README.md
+++ b/transformations/sentence_additions/README.md
@@ -1,4 +1,4 @@
-# Sentence additions
+# Sentence Additions 🦎  + ⌨️ → 🐍
 This perturbation adds generated sentence to all types of text sources (sentence, paragraph, etc.) by passing the input text to a GPT-2 Text Generation model.
 
 Author name: Timothy Sum Hon Mun (timothy22000@gmail.com)
@@ -7,12 +7,7 @@ Author name: Timothy Sum Hon Mun (timothy22000@gmail.com)
 This transformation will take in an input text and generate additional sentences to perturbe the inputs that have been shown by Jia and Liang, 2017 to impact model performance. This can be used to test model robustness. 
 
 ## What tasks does it intend to benefit?
-This perturbation would benefit all tasks on text classification and generation. 
-
-Benchmark results:
-
-- Sentiment analysis: we run sentiment analysis on a 1% sample of the IMDB dataset. The original accuracy is 956 and the perturbed accuracy is 95.2.
-- Text summarization: we run text summarization on a 1% sample of the xsum dataset. The original BLEU is 15.99 and the perturbed BLEU is 9.75.
+This perturbation would benefit all tasks on text classification and generation.
 
 ## Related work
 

--- a/transformations/sentence_additions/README.md
+++ b/transformations/sentence_additions/README.md
@@ -13,7 +13,6 @@ This transformation uses GPT-2 to generate new grammatical sentence that will be
 Run code below to evaluate:
 ```python evaluate.py -t ButterFingersPerturbation -task TEXT_CLASSIFICATION -m "textattack/roberta-base-SST-2" -d "sst2"```
 
-
 Accuracy of a RoBERTa model tuned on SST-2 (model: "textattack/roberta-base-SST-2") on a subset of the SST-2 dataset = 95.74
 
 Accuracy of the same model on the perturbed set = 89.0

--- a/transformations/sentence_additions/README.md
+++ b/transformations/sentence_additions/README.md
@@ -1,10 +1,10 @@
 # Sentence additions
 This perturbation adds generated sentence to all types of text sources (sentence, paragraph, etc.) by passing the input text to a GPT-2 Text Generation model.
 
-Author name: Timothy Sum Hon Mun (timothy2200@gmail.com)
+Author name: Timothy Sum Hon Mun (timothy22000@gmail.com)
 
 ## What type of a transformation is this?
-This transformation will take in an input text and generate additional sentences to perturbe the inputs that have been show by Jia and Liang, 2017 to be impact model performance. This can be used to test model robustness. 
+This transformation will take in an input text and generate additional sentences to perturbe the inputs that have been shown by Jia and Liang, 2017 to impact model performance. This can be used to test model robustness. 
 
 ## What tasks does it intend to benefit?
 This perturbation would benefit all tasks on text classification and generation. 
@@ -42,5 +42,5 @@ We use its implementation from huggingface (https://huggingface.co/gpt2).
 
 ## What are the limitations of this transformation?
 
-This transformation will only change the input text that has more than one sentence. 
+The text generated from this transformation is dependent on the pre-trained GPT-2 language model so it would perform less well on topics it has not seen. It is also less robust than the GPT-3 model which was trained on a much larger dataset and has more parameters.
 

--- a/transformations/sentence_additions/README.md
+++ b/transformations/sentence_additions/README.md
@@ -13,8 +13,10 @@ This transformation uses GPT-2 to generate new grammatical sentence that will be
 Run code below to evaluate:
 ```python evaluate.py -t ButterFingersPerturbation -task TEXT_CLASSIFICATION -m "textattack/roberta-base-SST-2" -d "sst2"```
 
-The accuracy of a RoBERTa model (fine-tuned on SST-2) (model: "textattack/roberta-base-SST-2") on a subset of SST-2 sentiment dataset = 95.74
-The accuracy of the same model on the perturbed set = 89.0
+
+Accuracy of a RoBERTa model tuned on SST-2 (model: "textattack/roberta-base-SST-2") on a subset of the SST-2 dataset = 95.74
+
+Accuracy of the same model on the perturbed set = 89.0
 
 ## What tasks does it intend to benefit?
 This perturbation would benefit all tasks on text classification and generation.

--- a/transformations/sentence_additions/README.md
+++ b/transformations/sentence_additions/README.md
@@ -4,14 +4,18 @@ This perturbation adds generated sentence to all types of text sources (sentence
 Author name: Timothy Sum Hon Mun (timothy22000@gmail.com)
 
 ## What type of a transformation is this?
-This transformation will take in an input text and generate additional sentences to perturbe the inputs that have been shown by Jia and Liang, 2017 to impact model performance. This can be used to test model robustness. 
+This transformation will take in an input text and generate additional sentences to perturbe the inputs that have been shown by Jia and Liang, 2017 to impact model performance. This can be used to test model robustness.
+
+The AddSent method in the paper which is in the Q&A setting requires mutation of the original question asked and generating a fake answer based on that. Then, converting them into a statement that is added a sentence to the input text as an adversarial example.
+
+This transformation uses GPT-2 to generate new grammatical sentence that will be added to the input text so it does not require any question mutation and fake answer.
 
 ## What tasks does it intend to benefit?
 This perturbation would benefit all tasks on text classification and generation.
 
 ## Related work
 
-This is uses ideas that are related to the AddSent and AddOneSent adversarial examples covered in this EMNLP 2017 paper:
+This is inspired by ideas that are related to the AddSent and AddOneSent adversarial examples covered in this EMNLP 2017 paper:
 
 ```bibtex
 @article{jia2017adversarial,

--- a/transformations/sentence_additions/README.md
+++ b/transformations/sentence_additions/README.md
@@ -1,0 +1,46 @@
+# Sentence additions
+This perturbation adds generated sentence to all types of text sources (sentence, paragraph, etc.) by passing the input text to a GPT-2 Text Generation model.
+
+Author name: Timothy Sum Hon Mun (timothy2200@gmail.com)
+
+## What type of a transformation is this?
+This transformation will take in an input text and generate additional sentences to perturbe the inputs that have been show by Jia and Liang, 2017 to be impact model performance. This can be used to test model robustness. 
+
+## What tasks does it intend to benefit?
+This perturbation would benefit all tasks on text classification and generation. 
+
+Benchmark results:
+
+- Sentiment analysis: we run sentiment analysis on a 1% sample of the IMDB dataset. The original accuracy is 956 and the perturbed accuracy is 95.2.
+- Text summarization: we run text summarization on a 1% sample of the xsum dataset. The original BLEU is 15.99 and the perturbed BLEU is 9.75.
+
+## Related work
+
+This is uses ideas that are related to the AddSent and AddOneSent adversarial examples covered in this EMNLP 2017 paper:
+
+```bibtex
+@article{jia2017adversarial,
+  title={Adversarial examples for evaluating reading comprehension systems},
+  author={Jia, Robin and Liang, Percy},
+  journal={arXiv preprint arXiv:1707.07328},
+  year={2017}
+}
+}
+```
+
+The GPT-2 text generation model is from the following paper:
+
+```bibtex
+@article{radford2019language,
+  title={Language Models are Unsupervised Multitask Learners},
+  author={Radford, Alec and Wu, Jeff and Child, Rewon and Luan, David and Amodei, Dario and Sutskever, Ilya},
+  year={2019}
+}
+```
+
+We use its implementation from huggingface (https://huggingface.co/gpt2).
+
+## What are the limitations of this transformation?
+
+This transformation will only change the input text that has more than one sentence. 
+

--- a/transformations/sentence_additions/README.md
+++ b/transformations/sentence_additions/README.md
@@ -10,6 +10,12 @@ The AddSent method in the paper which is in the Q&A setting requires mutation of
 
 This transformation uses GPT-2 to generate new grammatical sentence that will be added to the input text so it does not require any question mutation and fake answer.
 
+Run code below to evaluate:
+```python evaluate.py -t ButterFingersPerturbation -task TEXT_CLASSIFICATION -m "textattack/roberta-base-SST-2" -d "sst2"```
+
+The accuracy of a RoBERTa model (fine-tuned on SST-2) (model: "textattack/roberta-base-SST-2") on a subset of SST-2 sentiment dataset = 95.74
+The accuracy of the same model on the perturbed set = 89.0
+
 ## What tasks does it intend to benefit?
 This perturbation would benefit all tasks on text classification and generation.
 

--- a/transformations/sentence_additions/__init__.py
+++ b/transformations/sentence_additions/__init__.py
@@ -1,0 +1,1 @@
+from .transformation import *

--- a/transformations/sentence_additions/requirements.txt
+++ b/transformations/sentence_additions/requirements.txt
@@ -1,1 +1,0 @@
-transformers==4.7.0

--- a/transformations/sentence_additions/requirements.txt
+++ b/transformations/sentence_additions/requirements.txt
@@ -1,0 +1,1 @@
+transformers==4.7.0

--- a/transformations/sentence_additions/test.json
+++ b/transformations/sentence_additions/test.json
@@ -1,0 +1,60 @@
+{
+  "type": "sentence_additions",
+  "test_cases": [
+    {
+      "class": "SentenceAdditions",
+      "inputs": {
+        "sentence": "John was not the person that I had imagined."
+      },
+      "outputs": [
+        {
+          "sentence": "John was not the person that I had imagined. I had thought that he would have strong qualities. I think I knew that I wanted to do something"
+        }
+      ]
+    },
+    {
+      "class": "SentenceAdditions",
+      "inputs": {
+        "sentence": "Hello, I'm a language model."
+      },
+      "outputs": [
+        {
+          "sentence": "Hello, I'm a language model. This language model knows lots of stuff about you. It knows where you live, what you like to eat, which movie you watch,"
+        }
+      ]
+    },
+    {
+      "class": "SentenceAdditions",
+      "inputs": {
+        "sentence": "Apple was founded by Steve Jobs, Steve Wozniak and Ronald Wayne in April 1976."
+      },
+      "outputs": [
+        {
+          "sentence": "Apple was founded by Steve Jobs, Steve Wozniak and Ronald Wayne in April 1976.\\n\\nSince then, it's grown to become the world's largest technology company"
+        }
+      ]
+    },
+    {
+      "class": "SentenceAdditions",
+      "inputs": {
+        "sentence": "Historically, the uncertainty principle has been confused with a related effect in physics, called the observer effect, which notes that measurements of certain systems cannot be made without affecting the system, that is, without changing something in a system."
+      },
+      "outputs": [
+        {
+          "sentence": "Historically, the uncertainty principle has been confused with a related effect in physics, called the observer effect, which notes that measurements of certain systems cannot be made without affecting the system, that is, without changing something in a system. The difference, in contrast, is that the uncertainty principle says that no amount of uncertainty in the measurement will affect the meaning"
+        }
+      ]
+    },
+    {
+      "class": "SentenceAdditions",
+      "inputs": {
+        "sentence": "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with someof the finest nuclear medicine consultants from a wide variety of specialist fields, attracted from London's major teaching hospitals."
+      },
+      "outputs": [
+        {
+          "sentence": "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with someof the finest nuclear medicine consultants from a wide variety of specialist fields, attracted from London's major teaching hospitals. We are also a leading provider for a wide range of diagnostic and clinical imaging tests and procedures, including brain tumour scans"
+        }
+      ]
+    }
+  ]
+}

--- a/transformations/sentence_additions/test.json
+++ b/transformations/sentence_additions/test.json
@@ -15,6 +15,18 @@
     {
       "class": "SentenceAdditions",
       "inputs": {
+        "sentence": "The Battle of Caen on 26 July 1346 was an assault on the French-held town by a force of archers and men-at-arms, part of an invading English army under King Edward III during the Hundred Years' War.",
+        "prompt": true
+      },
+      "outputs": [
+        {
+          "sentence": "The Battle of Caen on 26 July 1346 was an assault on the French-held town by a force of archers and men-at-arms, part of an invading English army under King Edward III during the Hundred Years' War. PARAPHRASE:  (A) The English army advanced, under the leadership of Edward, to attack a city."
+        }
+      ]
+    },
+    {
+      "class": "SentenceAdditions",
+      "inputs": {
         "sentence": "Hello, I'm a language model."
       },
       "outputs": [
@@ -37,6 +49,18 @@
     {
       "class": "SentenceAdditions",
       "inputs": {
+        "sentence": "Apple was founded by Steve Jobs, Steve Wozniak and Ronald Wayne in April 1976.",
+        "prompt": true
+      },
+      "outputs": [
+        {
+          "sentence": "Apple was founded by Steve Jobs, Steve Wozniak and Ronald Wayne in April 1976. PARAPHRASE:  (Mozart, Beethoven, Goethe, Mozart, Bach, Liszt, Beethoven, Mozart, Mozart) Apple Computer Inc. was launched in 1976 by Steve Jobs in Cupertino, California,"
+        }
+      ]
+    },
+    {
+      "class": "SentenceAdditions",
+      "inputs": {
         "sentence": "Historically, the uncertainty principle has been confused with a related effect in physics, called the observer effect, which notes that measurements of certain systems cannot be made without affecting the system, that is, without changing something in a system."
       },
       "outputs": [
@@ -53,6 +77,18 @@
       "outputs": [
         {
           "sentence": "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with the finest nuclear medicine consultants from a wide variety of specialist fields. We also own the world's largest and most powerful MRI scanner - called the Trinity XA - and a variety of radiation technology equipment including nuclear medicine detectors, detectors of radionuclides such as"
+        }
+      ]
+    },
+    {
+      "class": "SentenceAdditions",
+      "inputs": {
+        "sentence": "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with the finest nuclear medicine consultants from a wide variety of specialist fields.",
+        "prompt": true
+      },
+      "outputs": [
+        {
+          "sentence": "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with the finest nuclear medicine consultants from a wide variety of specialist fields. PARAPHRASE: ________________________________________________________________________________ ________________________________________________________________________________ Trinity Health has a proud and productive history in the health care industry. We hold that quality care is a shared resource and our commitment to ensuring"
         }
       ]
     }

--- a/transformations/sentence_additions/test.json
+++ b/transformations/sentence_additions/test.json
@@ -4,11 +4,11 @@
     {
       "class": "SentenceAdditions",
       "inputs": {
-        "sentence": "John was not the person that I had imagined."
+        "sentence": "The Battle of Caen on 26 July 1346 was an assault on the French-held town by a force of archers and men-at-arms, part of an invading English army under King Edward III during the Hundred Years' War."
       },
       "outputs": [
         {
-          "sentence": "John was not the person that I had imagined. I had thought that he would have strong qualities. I think I knew that I wanted to do something"
+          "sentence": "The Battle of Caen on 26 July 1346 was an assault on the French-held town by a force of archers and men-at-arms, part of an invading English army under King Edward III during the Hundred Years' War. It took place in a wooded valley near St. Quentin's Abbey, a pilgrimage spot. Caen was founded in 1271"
         }
       ]
     },
@@ -19,7 +19,7 @@
       },
       "outputs": [
         {
-          "sentence": "Hello, I'm a language model. This language model knows lots of stuff about you. It knows where you live, what you like to eat, which movie you watch,"
+          "sentence": "Hello, I'm a language model. It's not the first, nor the last, or even the most efficient. It's simply the one that I like to know about, and that I'm very happy to share. But it can be useful — in the sense that it's a place where your programming language models can get a little help from you, a place where"
         }
       ]
     },
@@ -30,7 +30,7 @@
       },
       "outputs": [
         {
-          "sentence": "Apple was founded by Steve Jobs, Steve Wozniak and Ronald Wayne in April 1976.\\n\\nSince then, it's grown to become the world's largest technology company"
+          "sentence": "Apple was founded by Steve Jobs, Steve Wozniak and Ronald Wayne in April 1976. It is not the first of its kind, but it's one of the biggest and most successful. The company provides a range of products, including computer, mobile devices and hardware. In the third quarter of this year, Apple recorded over $43 billion in revenue. But at its"
         }
       ]
     },
@@ -41,18 +41,18 @@
       },
       "outputs": [
         {
-          "sentence": "Historically, the uncertainty principle has been confused with a related effect in physics, called the observer effect, which notes that measurements of certain systems cannot be made without affecting the system, that is, without changing something in a system. The difference, in contrast, is that the uncertainty principle says that no amount of uncertainty in the measurement will affect the meaning"
+          "sentence": "Historically, the uncertainty principle has been confused with a related effect in physics, called the observer effect, which notes that measurements of certain systems cannot be made without affecting the system, that is, without changing something in a system. One example is the fact that different kinds of clocks can be used in a system with a known frequency. One cannot determine if a clock has been"
         }
       ]
     },
     {
       "class": "SentenceAdditions",
       "inputs": {
-        "sentence": "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with someof the finest nuclear medicine consultants from a wide variety of specialist fields, attracted from London's major teaching hospitals."
+        "sentence": "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with the finest nuclear medicine consultants from a wide variety of specialist fields."
       },
       "outputs": [
         {
-          "sentence": "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with someof the finest nuclear medicine consultants from a wide variety of specialist fields, attracted from London's major teaching hospitals. We are also a leading provider for a wide range of diagnostic and clinical imaging tests and procedures, including brain tumour scans"
+          "sentence": "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with the finest nuclear medicine consultants from a wide variety of specialist fields. We also own the world's largest and most powerful MRI scanner - called the Trinity XA - and a variety of radiation technology equipment including nuclear medicine detectors, detectors of radionuclides such as"
         }
       ]
     }

--- a/transformations/sentence_additions/transformation.py
+++ b/transformations/sentence_additions/transformation.py
@@ -1,0 +1,38 @@
+from interfaces.SentenceOperation import SentenceOperation
+from tasks.TaskTypes import TaskType
+from transformers import pipeline, set_seed
+
+"""
+Adds generated sentence into provided sentences or paragraph to create adversarial examples.
+"""
+
+
+class SentenceAdditions(SentenceOperation):
+    tasks = [
+        TaskType.TEXT_CLASSIFICATION,
+        TaskType.TEXT_TO_TEXT_GENERATION,
+    ]
+    languages = ["en"]
+    heavy = True
+
+    def __init__(self, seed=42, max_outputs=1, max_length=30, model='gpt2-xl'):
+        super().__init__(seed, max_outputs=max_outputs)
+        self.seed = seed
+        self.model = model
+        self.max_outputs = max_outputs
+        self.max_length = max_length
+
+    def generate(self, sentence: str):
+        perturbed = self.sentence_additions(text=sentence)
+        return perturbed
+
+    def sentence_additions(self, text):
+        set_seed(self.seed)
+        generator = pipeline('text-generation', model=self.model)
+        outputs = generator(text, max_length = self.max_length, num_return_sequences = self.max_outputs)
+        perturbed = []
+        for sents_with_additions in outputs:
+            for key, value in sents_with_additions.items():
+                perturbed.append(value)
+
+        return perturbed

--- a/transformations/sentence_additions/transformation.py
+++ b/transformations/sentence_additions/transformation.py
@@ -43,8 +43,7 @@ class SentenceAdditions(SentenceOperation):
 
 # For testing outputs
 if __name__ == "__main__":
-    print(tf.__spec__)
-    # sentence_addition = SentenceAdditions()
-    # text = "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with the finest nuclear medicine consultants from a wide variety of specialist fields."
-    # new_text = sentence_addition.generate(text, prompt=True)
-    # print(new_text)
+    sentence_addition = SentenceAdditions()
+    text = "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with the finest nuclear medicine consultants from a wide variety of specialist fields."
+    new_text = sentence_addition.generate(text, prompt=True)
+    print(new_text)

--- a/transformations/sentence_additions/transformation.py
+++ b/transformations/sentence_additions/transformation.py
@@ -13,6 +13,8 @@ class SentenceAdditions(SentenceOperation):
         TaskType.TEXT_TO_TEXT_GENERATION,
     ]
     languages = ["en"]
+
+    keywords = ["discourse", "model-based", "transformer-based", "visual", "possible-meaning-alteration", "high-generations"]
     heavy = True
 
     def __init__(self, seed=0, max_outputs=1, max_length=75, model='gpt2-xl'):
@@ -22,18 +24,27 @@ class SentenceAdditions(SentenceOperation):
         self.max_outputs = max_outputs
         self.max_length = max_length
 
-    def generate(self, sentence: str):
-        perturbed = self.sentence_additions(text=sentence)
+    def generate(self, sentence: str, prompt_text=" PARAPHRASE: ", prompt=False):
+        perturbed = self.sentence_additions(text=sentence, prompt_text=prompt_text, prompt=prompt)
         return perturbed
 
-    def sentence_additions(self, text):
+    def sentence_additions(self, text, prompt_text, prompt):
         set_seed(self.seed)
         generator = pipeline('text-generation', model=self.model)
+        if(prompt):
+            text = text + prompt_text
         outputs = generator(text, max_length = self.max_length, num_return_sequences = self.max_outputs)
         perturbed = []
         for sents_with_additions in outputs:
             for key, value in sents_with_additions.items():
-                print(value)
                 perturbed.append(value)
 
         return perturbed
+
+# For testing outputs
+if __name__ == "__main__":
+    print(tf.__spec__)
+    # sentence_addition = SentenceAdditions()
+    # text = "Trinity Medical Imaging is one of the foremost providers of private nuclear medicine imaging in London and Surrey. We work with the finest nuclear medicine consultants from a wide variety of specialist fields."
+    # new_text = sentence_addition.generate(text, prompt=True)
+    # print(new_text)

--- a/transformations/sentence_additions/transformation.py
+++ b/transformations/sentence_additions/transformation.py
@@ -15,7 +15,7 @@ class SentenceAdditions(SentenceOperation):
     languages = ["en"]
     heavy = True
 
-    def __init__(self, seed=42, max_outputs=1, max_length=30, model='gpt2-xl'):
+    def __init__(self, seed=0, max_outputs=1, max_length=75, model='gpt2-xl'):
         super().__init__(seed, max_outputs=max_outputs)
         self.seed = seed
         self.model = model

--- a/transformations/sentence_additions/transformation.py
+++ b/transformations/sentence_additions/transformation.py
@@ -33,6 +33,7 @@ class SentenceAdditions(SentenceOperation):
         perturbed = []
         for sents_with_additions in outputs:
             for key, value in sents_with_additions.items():
+                print(value)
                 perturbed.append(value)
 
         return perturbed


### PR DESCRIPTION
**Notes**

Added a sentence additions transformation to create perturbed outputs based on ideas and results from this paper where adding sentences to the original text to test the robustness of models.

The method that I employed to add sentences is by adding generated sentences from the GPT-2 model to create the perturbations so that can be applied to any settings other than the Q&A setting in original paper. The user can pass in a sentence or paragraph as input text.

More details in README.md

**Changes**

1. Added SentenceAdditionsTransformation
2. Added test cases for transformation
