### PR TITLE
Added transformation to replace nouns with hyponyms/hypernyms

### DIFF
--- a/transformations/replace_with_hyponyms_hypernyms/README.md
+++ b/transformations/replace_with_hyponyms_hypernyms/README.md
@@ -1,0 +1,34 @@
+# Replace nouns with hyponyms or hypernyms 👨 ️→ 🐍🧔
+This perturbation replaces common nouns with other related words that are either hyponyms or hypernyms. Hyponyms of a word are more specific in meaning (such as a sub-class of the word), eg: 'spoon' is a hyponym of 'cutlery'. Hypernyms are related words with a broader meaning (such as a generic category /super-class of the word), eg: 'colour' is a hypernym of 'red'. Not every word will have a hypernym or hyponym.
+
+Contributors: Ananya B. Sai, Tanay Dixit (Indian Institute of Technology, Madras)
+
+## What type of a transformation is this?
+This transformation acts like a perturbation and makes lexical substitutions using the hyponyms or hypernyms of the common nouns in a sentence when possible (i.e., when atleast one noun in the sentence has a hyponym or hypernym).
+
+## What tasks does it intend to benefit?
+This perturbation would benefit all tasks which have a sentence/paragraph/document as input like text classification, text generation, etc. Since the transformation is only dealing with the hyponyms and hypernyms of nouns, it can be used to augment or benchmark performance on tasks like sentiment classification. For example, 'United Airlines has horrible service' -> 'United Airlines has horrible seating' (using hyponym replacement) or 'United Airlines has horrible quality' (using hypernym replacement).
+
+## Previous Work and References
+1) The implementation of this perturbation uses Checklist.
+```bibtex
+@inproceedings{ribeiro-etal-2020-beyond,
+    title = "Beyond Accuracy: Behavioral Testing of {NLP} Models with {C}heck{L}ist",
+    author = "Ribeiro, Marco Tulio  and
+      Wu, Tongshuang  and
+      Guestrin, Carlos  and
+      Singh, Sameer",
+    booktitle = "Proceedings of the 58th Annual Meeting of the Association for Computational Linguistics",
+    month = jul,
+    year = "2020",
+    address = "Online",
+    publisher = "Association for Computational Linguistics",
+    url = "https://www.aclweb.org/anthology/2020.acl-main.442",
+    doi = "10.18653/v1/2020.acl-main.442",
+    pages = "4902--4912",
+    abstract = "Although measuring held-out accuracy has been the primary approach to evaluate generalization, it often overestimates the performance of NLP models, while alternative approaches for evaluating models either focus on individual tasks or on specific behaviors. Inspired by principles of behavioral testing in software engineering, we introduce CheckList, a task-agnostic methodology for testing NLP models. CheckList includes a matrix of general linguistic capabilities and test types that facilitate comprehensive test ideation, as well as a software tool to generate a large and diverse number of test cases quickly. We illustrate the utility of CheckList with tests for three tasks, identifying critical failures in both commercial and state-of-art models. In a user study, a team responsible for a commercial sentiment analysis model found new and actionable bugs in an extensively tested model. In another user study, NLP practitioners with CheckList created twice as many tests, and found almost three times as many bugs as users without it.",
+}
+```
+
+## What are the limitations of this transformation?
+While the transformation can be used for data augmentation or to check for performance difference in tasks like sentiment classification, it has to be cautiously used. Since the transformation does affect meaning of a sentence, it is not applicable to tasks like paraphrases [unless, we only want to augment the negative (i.e., not paraphrases) class]. Even for the task of sentiment classification, while the sentiment is usually preserved in case of hyponym/hypernym replacement of only the nouns in a sentence, it is possible that a hypernym would change a positive or negative sentiment to neutral (especially when abstract nouns are involved).

--- a/transformations/replace_with_hyponyms_hypernyms/__init__.py
+++ b/transformations/replace_with_hyponyms_hypernyms/__init__.py
@@ -1,0 +1,1 @@
+from .transformation import *

--- a/transformations/replace_with_hyponyms_hypernyms/test.json
+++ b/transformations/replace_with_hyponyms_hypernyms/test.json
@@ -1,0 +1,284 @@
+{
+    "type": "replace_hyponyms",
+    "test_cases": [
+        {
+            "class": "ReplaceHyponyms",
+            "inputs": {
+                "sentence": "Andrew finally returned the French book to Chris that I bought last week."
+            },
+            "outputs": [
+                {
+                    "sentence": "Andrew finally returned the French notebook to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French card to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French novel to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French journal to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French dictionary to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French textbook to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French paperback to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French catalog to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French catalogue to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French manual to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French album to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French folder to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French diary to Chris that I bought last week."
+                }
+            ]
+        },
+        {
+            "class": "ReplaceHyponyms",
+            "inputs": {
+                "sentence": "This car looks fascinating"
+            },
+            "outputs": [
+                {
+                    "sentence": "This tank looks fascinating"
+                },
+                {
+                    "sentence": "This van looks fascinating"
+                },
+                {
+                    "sentence": "This bus looks fascinating"
+                },
+                {
+                    "sentence": "This hack looks fascinating"
+                },
+                {
+                    "sentence": "This flat looks fascinating"
+                },
+                {
+                    "sentence": "This heap looks fascinating"
+                },
+                {
+                    "sentence": "This wagon looks fascinating"
+                },
+                {
+                    "sentence": "This SUV looks fascinating"
+                },
+                {
+                    "sentence": "This diner looks fascinating"
+                }
+            ]
+        },
+        {
+            "class": "ReplaceHyponyms",
+            "inputs": {
+                "sentence": "There is no love for this product."
+            },
+            "outputs": [
+                {
+                    "sentence": "There is no loyalty for this product."
+                },
+                {
+                    "sentence": "There is no take for this product."
+                },
+                {
+                    "sentence": "There is no romance for this product."
+                },
+                {
+                    "sentence": "There is no caring for this product."
+                },
+                {
+                    "sentence": "There is no love for this book."
+                },
+                {
+                    "sentence": "There is no love for this movie."
+                },
+                {
+                    "sentence": "There is no love for this film."
+                },
+                {
+                    "sentence": "There is no love for this picture."
+                },
+                {
+                    "sentence": "There is no love for this work."
+                },
+                {
+                    "sentence": "There is no love for this album."
+                },
+                {
+                    "sentence": "There is no love for this job."
+                },
+                {
+                    "sentence": "There is no love for this cartoon."
+                },
+                {
+                    "sentence": "There is no love for this fruit."
+                }
+            ]
+        },
+        {
+            "class": "ReplaceHyponyms",
+            "inputs": {
+                "sentence": "United Airlines has horrible service"
+            },
+            "outputs": [
+                {
+                    "sentence": "United Airlines has horrible seating"
+                }
+            ]
+        }
+    ]
+}
+{
+    "type": "replace_hypernyms",
+    "test_cases": [
+        {
+            "class": "ReplaceHypernyms",
+            "inputs": {
+                "sentence": "Andrew finally returned the French book to Chris that I bought last week."
+            },
+            "outputs": [
+                {
+                    "sentence": "Andrew finally returned the French register to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French collection to Chris that I bought last week."
+                },
+                {
+                    "sentence": "Andrew finally returned the French work to Chris that I bought last week."
+                }
+            ]
+        },
+        {
+            "class": "ReplaceHypernyms",
+            "inputs": {
+                "sentence": "This car looks fascinating"
+            },
+            "outputs": [
+                {
+                    "sentence": "This structure looks fascinating"
+                },
+                {
+                    "sentence": "This object looks fascinating"
+                },
+                {
+                    "sentence": "This artifact looks fascinating"
+                },
+                {
+                    "sentence": "This room looks fascinating"
+                },
+                {
+                    "sentence": "This construction looks fascinating"
+                },
+                {
+                    "sentence": "This area looks fascinating"
+                },
+                {
+                    "sentence": "This vehicle looks fascinating"
+                },
+                {
+                    "sentence": "This container looks fascinating"
+                },
+                {
+                    "sentence": "This unit looks fascinating"
+                },
+                {
+                    "sentence": "This whole looks fascinating"
+                },
+                {
+                    "sentence": "This compartment looks fascinating"
+                },
+                {
+                    "sentence": "This entity looks fascinating"
+                },
+                {
+                    "sentence": "This transport looks fascinating"
+                }
+            ]
+        },
+        {
+            "class": "ReplaceHypernyms",
+            "inputs": {
+                "sentence": "There is no love for this product."
+            },
+            "outputs": [
+                {
+                    "sentence": "There is no content for this product."
+                },
+                {
+                    "sentence": "There is no desire for this product."
+                },
+                {
+                    "sentence": "There is no cause for this product."
+                },
+                {
+                    "sentence": "There is no process for this product."
+                },
+                {
+                    "sentence": "There is no link for this product."
+                },
+                {
+                    "sentence": "There is no number for this product."
+                },
+                {
+                    "sentence": "There is no score for this product."
+                },
+                {
+                    "sentence": "There is no quantity for this product."
+                },
+                {
+                    "sentence": "There is no state for this product."
+                },
+                {
+                    "sentence": "There is no unit for this product."
+                },
+                {
+                    "sentence": "There is no activity for this product."
+                },
+                {
+                    "sentence": "There is no amount for this product."
+                },
+                {
+                    "sentence": "There is no knowledge for this product."
+                }
+            ]
+        },
+        {
+            "class": "ReplaceHypernyms",
+            "inputs": {
+                "sentence": "United Airlines has horrible service"
+            },
+            "outputs": [
+                {
+                    "sentence": "United Airlines has horrible quality"
+                },
+                {
+                    "sentence": "United Airlines has horrible business"
+                },
+                {
+                    "sentence": "United Airlines has horrible personnel"
+                },
+                {
+                    "sentence": "United Airlines has horrible maintenance"
+                },
+                {
+                    "sentence": "United Airlines has horrible transportation"
+                }
+            ]
+        }
+    ]
+}

--- a/transformations/replace_with_hyponyms_hypernyms/transformation.py
+++ b/transformations/replace_with_hyponyms_hypernyms/transformation.py
@@ -1,0 +1,114 @@
+import numpy as np
+import spacy
+import random
+from checklist.editor import Editor
+
+from interfaces.SentenceOperation import SentenceOperation
+from tasks.TaskTypes import TaskType
+
+
+class ReplaceHyponyms(SentenceOperation):
+    tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION]
+    languages = ["en"]
+
+    def __init__(self, n=1, seed=0, max_output=2):
+        super().__init__(seed)
+        self.nlp = spacy.load("en_core_web_sm")
+        self.n = n
+        self.max_output = max_output
+        self.editor = Editor()
+
+    def generate(self, sentence: str):
+        np.random.seed(self.seed)
+        words = []
+        perturbed_texts = []
+        tokens = self.nlp(sentence)
+        #Shuffle the tokens list so that all noun (and not just the beginning nouns) 
+        #have a fair chance at being picked.
+        shuf_tokens = list(tokens)
+        random.seed(0) #To get the same output as in test.json
+        random.shuffle(shuf_tokens)
+        for token in shuf_tokens:
+            if token.pos_ == 'NOUN':
+              words.append(token)
+              hyp_list = self.editor.hyponyms(sentence, token.text)
+              for hyp in hyp_list:
+                #Replace the noun with the hyponym
+                perturbed_texts.append(sentence.replace(token.text,hyp))
+              if len(perturbed_texts)>=self.max_output:
+                break
+        perturbed_texts = (
+            perturbed_texts[: self.max_output]
+            if len(perturbed_texts) > 0
+            else [sentence]
+        )
+        return perturbed_texts
+
+class ReplaceHypernyms(SentenceOperation):
+    tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION]
+    languages = ["en"]
+
+    def __init__(self, n=1, seed=0, max_output=2):
+        super().__init__(seed)
+        self.nlp = spacy.load("en_core_web_sm")
+        self.n = n
+        self.max_output = max_output
+        self.editor = Editor()
+
+    def generate(self, sentence: str):
+        np.random.seed(self.seed)
+        words = []
+        perturbed_texts = []
+        tokens = self.nlp(sentence)
+        #Shuffle the tokens list so that all noun (and not just the beginning nouns) 
+        #have a fair chance at being picked.
+        shuf_tokens = list(tokens)
+        random.seed(0) #To get the same output as in test.json
+        random.shuffle(shuf_tokens)
+        for token in shuf_tokens:
+            if token.pos_ == 'NOUN':
+              words.append(token)
+              hyp_list = self.editor.hypernyms(sentence, token.text)
+              for hyp in hyp_list:
+                #Replace the noun with the hypernym
+                perturbed_texts.append(sentence.replace(token.text,hyp))
+              if len(perturbed_texts)>=self.max_output:
+                break
+        perturbed_texts = (
+            perturbed_texts[: self.max_output]
+            if len(perturbed_texts) > 0
+            else [sentence]
+        )
+        return perturbed_texts
+
+#Uncomment the following to get the test.json output
+'''
+if __name__ == '__main__':
+    import json
+    from TestRunner import convert_to_snake_case
+
+    transformation = ReplaceHyponyms(max_output=13)
+    sentences = ["Andrew finally returned the French book to Chris that I bought last week.",
+                  "This car looks fascinating","There is no love for this product.",
+                  "United Airlines has horrible service"]
+    test_cases = []
+    for sentence in sentences:
+        test_cases.append({
+            "class": transformation.name(),
+            "inputs": {"sentence": sentence}, "outputs": [{"sentence": o} for o in transformation.generate(sentence)]}
+        )
+    json_file = {"type": convert_to_snake_case(transformation.name()), "test_cases": test_cases}
+    print(json.dumps(json_file, indent=4))
+    transformation = ReplaceHypernyms(max_output=13)
+    sentences = ["Andrew finally returned the French book to Chris that I bought last week.",
+                  "This car looks fascinating","There is no love for this product.",
+                  "United Airlines has horrible service"]
+    test_cases = []
+    for sentence in sentences:
+        test_cases.append({
+            "class": transformation.name(),
+            "inputs": {"sentence": sentence}, "outputs": [{"sentence": o} for o in transformation.generate(sentence)]}
+        )
+    json_file = {"type": convert_to_snake_case(transformation.name()), "test_cases": test_cases}
+    print(json.dumps(json_file, indent=4))
+'''


### PR DESCRIPTION
I had previously opened a draft pull request for the same transformation. Due to a few glitches, I am opening a new pull request after making the modifications suggested by the reviewers (@kaustubhdhole and @ashish3586 ) on the draft. In particular, 
1) the test cases are corrected in test.json file, 
2) I have added more details about the transformation in the README.md file
3) I've randomised the order of the nouns in the sentence so that every noun gets a fair chance at being picked first, rather than the order in which the nouns appear. 
4) I've removed any arbitrary bits of commented code. Currently only the code used to generate the outputs present in test.json file is present as a multi-line comment at the end of transformation.py.

Thanks for the reviews and inputs. I'll be on the look-out for any more suggestions.