### PR TITLE
adding named-entity-count filter

### DIFF
--- a/filters/named-entity-count/README.md
+++ b/filters/named-entity-count/README.md
@@ -1,0 +1,28 @@
+## named-entity-count filter
+
+Author: Vikas Raunak (viraunak@microsoft.com)
+
+## What type of a filter is this?
+
+This filter filters data where the number of Named Entities in the input match a specified threshold (based on the supported conditions).
+
+Supported conditions:
+- greater than: ">"
+- less than: "<"
+- greater equal to: ">="
+- less equal to: "<="
+- equal to: "=="
+
+## Why is measuring performance on this split important?
+
+Errors pertaining to Named Entities are quite common in a range of text generation systems (e.g. MT, Summarization, etc.). This filter will allow measuring performance on more fine-grained splits wrt Named Entities. Besides analysis, uses in error detection could be devised, e.g. detecting whether inputs and targets have same entity counts, etc.
+
+## Related Work
+
+A number of works (e.g. compare-mt [1]) analyze text generation model outputs with respect to different input complexity measures, such as length (implemented in the length filter), parse structure, etc.
+
+[1] compare-mt, Neubig et al. NAACL 2019 Demo Paper.
+
+## What are the limitations of this filter?
+
+The limitations of this filter are the limitations of the Named Entity Recognizer used, i.e. the counts could be inaccurate due to NER errors.

--- a/filters/named-entity-count/__init__.py
+++ b/filters/named-entity-count/__init__.py
@@ -1,0 +1,1 @@
+from .filter import *

--- a/filters/named-entity-count/filter.py
+++ b/filters/named-entity-count/filter.py
@@ -1,0 +1,84 @@
+import operator
+from typing import List
+
+import spacy
+
+from initialize import spacy_nlp
+from interfaces.SentenceOperation import (
+    SentenceAndTargetOperation,
+    SentenceOperation,
+)
+from tasks.TaskTypes import TaskType
+
+class NamedEntityCountFilter(SentenceOperation):
+    """
+    A filter on the count of named entities in a sentence.
+    """
+    tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION]
+    languages = ["en"]
+
+    def __init__(self, op: str = ">", threshold: int = 10):
+        super().__init__()
+        self.operator = self.parse_operator(op)
+        self.threshold = threshold
+        self.nlp = spacy_nlp if spacy_nlp else spacy.load("en_core_web_sm")
+
+    @staticmethod
+    def parse_operator(op):
+        ops = {
+            ">": operator.gt,
+            "<": operator.lt,
+            ">=": operator.ge,
+            "<=": operator.le,
+            "==": operator.eq,
+        }
+        return ops[op]
+
+    def filter(self, sentence: str = None) -> bool:
+        tokenized = self.nlp(sentence, disable=["parser", "tagger"])
+        named_entities = tokenized.ents
+        return self.operator(len(named_entities), self.threshold)
+
+
+class SentenceAndTargetNamedEntityCountFilter(SentenceAndTargetOperation):
+    """
+    An Example filter for SentenceAndTargetNamedEntityCountFilter interface.
+    """
+    tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION]
+    src_locales = ["en"]
+    tgt_languages = ["en"]
+
+    def __init__(self, ops: List[str] = None, thresholds: List[int] = None):
+        super().__init__()
+        self.operators = [NamedEntityCountFilter.parse_operator(op) for op in ops]
+        self.thresholds = thresholds
+        self.nlp = spacy_nlp if spacy_nlp else spacy.load("en_core_web_sm")
+
+        self._sanity_check()
+
+    def _sanity_check(self):
+        assert (
+            len(self.operators) == 2
+        ), "SentenceAndTargetOperation only support two inputs."
+        assert (
+            len(self.thresholds) == 2
+        ), "SentenceAndTargetOperation only support two inputs."
+
+    def filter(self, sentence: str = None, target: str = None) -> bool:
+        tokenized_sentence = self.nlp(
+            sentence, disable=["parser", "tagger"]
+        )
+        tokenized_target = self.nlp(
+            target, disable=["parser", "tagger"]
+        )
+
+        named_entities_sentence = tokenized_sentence.ents
+        named_entities_target = tokenized_target.ents
+
+        condition1 = self.operators[0](
+            len(named_entities_sentence), self.thresholds[0]
+        )
+        condition2 = self.operators[1](
+            len(named_entities_target), self.thresholds[1]
+        )
+        return condition1 and condition2

--- a/filters/named-entity-count/test.json
+++ b/filters/named-entity-count/test.json
@@ -1,0 +1,73 @@
+{
+    "type": "named-entity-count",
+    "test_cases": [
+        {
+            "class": "NamedEntityCountFilter",
+            "args": {
+                "op": ">",
+                "threshold": 2
+            },
+            "inputs": {
+                "sentence": "Gilbert played cricket in India with Michael and Jackson."
+            },
+            "outputs": true
+        },
+        {
+            "class": "NamedEntityCountFilter",
+            "args": {
+                "op": "<",
+                "threshold": 2
+            },
+            "inputs": {
+                "sentence": "America and Japan have signed treaty on automobile exports."
+            },
+            "outputs": false
+        },
+        {
+            "class": "NamedEntityCountFilter",
+            "args": {
+                "op": ">=",
+                "threshold": 1
+            },
+            "inputs": {
+                "sentence": "Novak Djokovic is the greatest tennis player of all time."
+            },
+            "outputs": true
+        },
+        {
+            "class": "NamedEntityCountFilter",
+            "args": {
+                "op": "==",
+                "threshold": 3
+            },
+            "inputs": {
+                "sentence": "La Flamenco is a dance performed in Spain in the region of Barcelona."
+            },
+            "outputs": true
+        },
+        {
+            "class": "SentenceAndTargetNamedEntityCountFilter",
+            "args": {
+                "ops": ["<=", ">="],
+                "thresholds": [2, 3]
+            },
+            "inputs": {
+                "sentence": "Andrew played cricket in India with Michael and Jackson.",
+                "target": "Andrew talked to Jackson about the importance of crickets in nature."
+            },
+            "outputs": false
+        },
+        {
+            "class": "SentenceAndTargetNamedEntityCountFilter",
+            "args": {
+                "ops": [">", "<"],
+                "thresholds": [1, 4]
+            },
+            "inputs": {
+                "sentence": "Jose Mourinho coaches the soccer club Roma.",
+                "target": "Jose Mourinho has coached the soccer clubs Real Madrid and Juventus."
+            },
+            "outputs": true
+        }
+    ]
+}


### PR DESCRIPTION
This filter allows filtering data based on the counts of named entities for more fine-grained analysis of text generation systems wrt named entities in the input. The PR includes test cases + Readme for more details. Thanks.