### PR TITLE
feat: azerty_qwerty_chars_swap

### DIFF
--- a/transformations/azerty_qwerty_chars_swap/README.md
+++ b/transformations/azerty_qwerty_chars_swap/README.md
@@ -1,0 +1,26 @@
+# Multilingual Keyboard Change: AZERTY / QWERTY
+This transformation acts like a perturbation by replacing some characters regarding a possible change of keyboard. Given a character `c_qwerty` located at a certain position in a QWERTY keyboard, it is replaced with the character `c_azerty` located at the same position of an AZERTY keyboard.
+
+## What type of a transformation is this?
+This transformation acts like a perturbation and makes lexical replacement.
+
+## What tasks does it intend to benefit?
+This perturbation would benefit all tasks which have a sentence/paragraph/document as input like text classification, text generation, etc. 
+
+## Previous Work and References
+
+```bibtex
+@article{bi2012multilingual,
+  title={Multilingual touchscreen keyboard design and optimization},
+  author={Bi, Xiaojun and Smith, Barton A and Zhai, Shumin},
+  journal={Human--Computer Interaction},
+  volume={27},
+  number={4},
+  pages={352--382},
+  year={2012},
+  publisher={Taylor \& Francis}
+}
+```
+
+## What are the limitations of this transformation?
+Unlike a paraphraser, it is not capable of generating linguistically diverse text.

--- a/transformations/azerty_qwerty_chars_swap/__init__.py
+++ b/transformations/azerty_qwerty_chars_swap/__init__.py
@@ -1,0 +1,1 @@
+from .transformation import *

--- a/transformations/azerty_qwerty_chars_swap/test.json
+++ b/transformations/azerty_qwerty_chars_swap/test.json
@@ -1,0 +1,27 @@
+{
+  "type": "AzertyQwertyCharsSwap",
+  "test_cases": [
+    {
+      "class": "AzertyQwertyCharsSwap",
+      "inputs": {
+        "sentence": "The US carried out a defensive airstrike in Kabul, targeting a suspected ISIS-K suicide bomber who posed an 'imminent' threat to the airport, US Central Command said Sunday."
+      },
+      "outputs": [
+        {
+          "sentence": "The US carried out a defensive airstrike in Kabul, targeting a suspected ISIS-K suicide bomber who posed an 'imminent' threat to the airport, US Central Command said Sunday."
+        }
+      ]
+    },
+    {
+      "class": "AzertyQwertyCharsSwap",
+      "inputs": {
+        "sentence": "The stage and its single RL10 engine provide the in-space propulsion needed to send NASA’s Orion spacecraft and its crew on a precise trajectory to the Moon for Artemis II, the first crewed mission of NASA’s Artemis lunar missions."
+      },
+      "outputs": [
+        {
+          "sentence": "The stage and its single RL10 engine provide the in-space propulsion needed to send NASA’s Orion spacecraft and its crew on a precise trajectory to the Moon for Artemis II, the first crewed mission of NASQ’s Qrtemis lunqr missions."
+        }
+      ]
+    }
+  ]
+}

--- a/transformations/azerty_qwerty_chars_swap/transformation.py
+++ b/transformations/azerty_qwerty_chars_swap/transformation.py
@@ -1,0 +1,27 @@
+import numpy as np
+from interfaces.SentenceOperation import SentenceOperation
+from tasks.TaskTypes import TaskType
+
+
+class AzertyQwertyCharsSwap(SentenceOperation):
+    tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION]
+    languages = ["en"]
+
+    def __init__(self, seed=0, percent_swap=0.2):
+        super().__init__(seed)
+        self.percent_swap = percent_swap
+        self.swap_dict = {"q": "a", "w": "z", "a": "q", "z": "w"}
+
+    def generate(self, sentence: str):
+        np.random.seed(self.seed)
+        new_sentence = ""
+        for char in sentence:
+            if char.lower() in self.swap_dict and np.random.uniform() < self.percent_swap:
+                new_char = self.swap_dict[char.lower()]
+                if char.isupper():
+                    new_char = new_char.upper()
+                new_sentence += new_char
+            else:
+                new_sentence += char
+
+        return [new_sentence]


### PR DESCRIPTION
Adding azerty_qwerty_chars_swap transformation.

This transformation acts like a perturbation by replacing some characters regarding a possible change of keyboard. Given a character `c_qwerty` located at a certain position in a QWERTY keyboard, it is replaced with the character `c_azerty` located at the same position of an AZERTY keyboard.
