### PR TITLE
Added Backtranslation for NER

### DIFF
--- a/transformations/back_translation_ner/README.md
+++ b/transformations/back_translation_ner/README.md
@@ -44,5 +44,5 @@ This transformation would benefit sequence labelling tasks such as named entity 
 ```
 
 ## What are the limitations of this transformation?
-This transformation intends to generate linguistically diverse paraphrases of the contexts around the entity mention(s) using backtranslation. The quality of the generated paraphrases solely depends on the underlying machine translation model; also the generated paraphrase sometimes do not preserve the underlying semantic meaning of the contexts.
+This transformation intends to generate linguistically diverse paraphrases of the contexts around the entity mention(s) using backtranslation. The quality of the generated paraphrases solely depends on the underlying machine translation model; also the generated paraphrase may not always preserve the underlying semantics of the contexts.
 Nevertheless, exploiting this transformation as a data augmentation strategy has been empirically shown to improve the performance of the underlying sequence (NER) model ([Yaseen and Langer, 2021](https://arxiv.org/abs/2108.11703)).

--- a/transformations/back_translation_ner/README.md
+++ b/transformations/back_translation_ner/README.md
@@ -22,6 +22,10 @@ tokens: `["Shannon", "received", "his", "doctorate", "from", "MIT", "in", "1940"
 
 tags: `["B-PER", "O", "O", "O", "O", "B-ORG", "O", "O", "O"]`
 
+
+Note that the transformation expects the list of `tokens` and `tags` as input, so please run your (*domain-specific*) entity tagger beforehand. Also, for `tags` the transformation expects the standard [IOB format](https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging)).
+
+
 ## What tasks does it intend to benefit?
 This transformation would benefit sequence labelling tasks such as named entity recognition.
 

--- a/transformations/back_translation_ner/README.md
+++ b/transformations/back_translation_ner/README.md
@@ -59,6 +59,12 @@ python evaluate.py -p 20 -t BackTranslationNER -m dslim/bert-base-NER -d bc2gm_c
 python evaluate.py -p 20 -t BackTranslationNER -m dslim/bert-base-NER -d jnlpba
 ```
 
+The following table reports the impact of backtranslation on model performance (accuracy) for various datasets.
+
+Output format: `accuracy without transformation -> accuracy with transformation (absolute difference)`
+
+where `absolute difference = accuracy with transformation - accuracy without transformation`
+
 | Dataset                     | `dslim/bert-base-NER-uncased`          | `dslim/bert-base-NER`     | `dslim/bert-large-NER`     |
 | --------------------------- | --------------------------- | --------------------------- | --------------------------- |
 | --------------------------- | --------------------------- | --------------------------- | --------------------------- |

--- a/transformations/back_translation_ner/README.md
+++ b/transformations/back_translation_ner/README.md
@@ -50,3 +50,17 @@ This transformation would benefit sequence labelling tasks such as named entity 
 ## What are the limitations of this transformation?
 This transformation intends to generate linguistically diverse paraphrases of the contexts around the entity mention(s) using backtranslation. The quality of the generated paraphrases solely depends on the underlying machine translation model; also the generated paraphrase may not always preserve the underlying semantics of the contexts.
 Nevertheless, exploiting this transformation as a data augmentation strategy has been empirically shown to improve the performance of the underlying sequence (NER) model ([Yaseen and Langer, 2021](https://arxiv.org/abs/2108.11703)).
+
+
+## Robustness Evaluation
+
+```python
+python evaluate.py -p 20 -t BackTranslationNER -m dslim/bert-base-NER -d bc2gm_corpus
+python evaluate.py -p 20 -t BackTranslationNER -m dslim/bert-base-NER -d jnlpba
+```
+
+| Dataset                     | `dslim/bert-base-NER-uncased`          | `dslim/bert-base-NER`     | `dslim/bert-large-NER`     |
+| --------------------------- | --------------------------- | --------------------------- | --------------------------- |
+| --------------------------- | --------------------------- | --------------------------- | --------------------------- |
+| [bc2gm_corpus](https://huggingface.co/datasets/bc2gm_corpus)              | 83.32 -> 89.37 (6.0)       | 87.99 -> 95.48 (7.4)   | 88.68 -> 96.36 (7.6)  |
+| [jnlpba](https://huggingface.co/datasets/jnlpba)                          | 78.08 -> 90.92 (12.84)     | 81.02 -> 95.32 (14.2)  | 81.44 -> 96.24 (14.7) |

--- a/transformations/back_translation_ner/README.md
+++ b/transformations/back_translation_ner/README.md
@@ -1,0 +1,48 @@
+# Backtranslation for Named Entity Recognition 🦓 ️→ 🐎
+This transformation exploits backtranslation (en &rarr; de &rarr; en) to generate diverse linguistic variations of the contexts around the entity mention(s).
+
+Contributors: Usama Yaseen (usama.yaseen@siemens.com), Stefan Langer (langer.stefan@siemens.com)
+
+Affiliation: Siemens AG
+
+## What type of a transformation is this?
+This transformation split the token sequences into segments of entity mention(s) or "contexts" around the entity mention(s). *Backtranslation* is used to paraphrase the contexts around the entity mention(s), thus resulting in an augmentation of the original token sequence.
+
+### Example
+
+**Inputs**
+
+tokens: `["Shannon", "received", "his", "PhD", "from", "MIT", "in", "1940", "."]`
+
+tags: `["B-PER", "O", "O", "O", "O", "B-ORG", "O", "O", "O"]`
+
+**Outputs**
+
+tokens: `["Shannon", "received", "his", "doctorate", "from", "MIT", "in", "1940", "."]`
+
+tags: `["B-PER", "O", "O", "O", "O", "B-ORG", "O", "O", "O"]`
+
+## What tasks does it intend to benefit?
+This transformation would benefit sequence labelling tasks such as named entity recognition.
+
+## Previous Work and References
+1) The transformation was proposed by [Yaseen and Langer, 2021](https://arxiv.org/abs/2108.11703).
+
+```bibtex
+@article{yaseen-and-langer-backtranslation-ner,
+  author    = {Usama Yaseen and
+               Stefan Langer},
+  title     = {Data Augmentation for Low-Resource Named Entity Recognition Using Backtranslation},
+  journal   = {CoRR},
+  volume    = {abs/2108.11703},
+  year      = {2021},
+  url       = {https://arxiv.org/abs/2108.11703},
+  archivePrefix = {arXiv},
+  eprint    = {2108.11703},
+  abstract = "The state of art natural language processing systems relies on sizable training datasets to achieve high performance. Lack of such datasets in the specialized low resource domains lead to suboptimal performance. In this work, we adapt backtranslation to generate high quality and linguistically diverse synthetic data for low-resource named entity recognition. We perform experiments on two datasets from the materials science (MaSciP) and biomedical domains (S800). The empirical results demonstrate the effectiveness of our proposed augmentation strategy, particularly in the low-resource scenario."
+}
+```
+
+## What are the limitations of this transformation?
+This transformation intends to generate linguistically diverse paraphrases of the contexts around the entity mention(s) using backtranslation. The quality of the generated paraphrases solely depends on the underlying machine translation model; also the generated paraphrase sometimes do not preserve the underlying semantic meaning of the contexts.
+Nevertheless, exploiting this transformation as a data augmentation strategy has been empirically shown to improve the performance of the underlying sequence (NER) model ([Yaseen and Langer, 2021](https://arxiv.org/abs/2108.11703)).

--- a/transformations/back_translation_ner/__init__.py
+++ b/transformations/back_translation_ner/__init__.py
@@ -1,0 +1,1 @@
+from .transformation import *

--- a/transformations/back_translation_ner/requirements.txt
+++ b/transformations/back_translation_ner/requirements.txt
@@ -1,1 +1,1 @@
-transformers==4.9.2
+transformers==4.6.1

--- a/transformations/back_translation_ner/requirements.txt
+++ b/transformations/back_translation_ner/requirements.txt
@@ -1,0 +1,1 @@
+transformers==4.9.2

--- a/transformations/back_translation_ner/requirements.txt
+++ b/transformations/back_translation_ner/requirements.txt
@@ -1,1 +1,0 @@
-transformers==4.6.1

--- a/transformations/back_translation_ner/test.json
+++ b/transformations/back_translation_ner/test.json
@@ -1,0 +1,50 @@
+{
+    "type": "back_translation_ner",
+    "test_cases": [
+        {
+            "class": "BackTranslationNER",
+            "inputs": {"token_sequence": "Musk has been the subject of criticism due to unorthodox or unscientific stances and highly publicized controversies.",
+            "tag_sequence": "B-PER O O O O O O O O O O O O O O O O"},
+            "outputs": [
+                {"token_sequence": "Musk has been criticized for unorthodox or unscientific attitudes and public controversies.",
+                "tag_sequence": "B-PER O O O O O O O O O O O"}
+            ]
+        },
+        {
+            "class": "BackTranslationNER",
+            "inputs": {"token_sequence": "The US Securities and Exchange Commission sued Musk for falsely tweeting that he had secured funding for a private takeover of Tesla.",
+            "tag_sequence": "O B-ORG I-ORG I-ORG I-ORG I-ORG O B-PER O O O O O O O O O O O O O B-ORG"},
+            "outputs": [
+              {"token_sequence": "The US Securities and Exchange Commission sued Musk because he mistakenly tweeted that he had secured funding for a private takeover of Tesla.",
+                "tag_sequence": "O B-ORG I-ORG I-ORG I-ORG I-ORG O B-PER O O O O O O O O O O O O O O B-ORG"}
+            ]
+          },
+          {
+            "class": "BackTranslationNER",
+            "inputs": {"token_sequence": "At age 10 , Musk developed an interest in computing and video games and purchased a Commodore VIC-20.",
+            "tag_sequence": "O O O O B-PER O O O O O O O O O O O B-DEVICE I-DEVICE"},
+            "outputs": [
+              {"token_sequence": "At the age of 10 years, Musk developed an interest in computer and video games and bought a Commodore VIC-20.",
+                "tag_sequence": "O O O O O O B-PER O O O O O O O O O O O B-DEVICE I-DEVICE"}
+            ]
+          },
+          {
+            "class": "BackTranslationNER",
+            "inputs": {"token_sequence": "Shannon received his PhD from MIT in 1940.",
+            "tag_sequence": "B-PER O O O O B-ORG O O"},
+            "outputs": [
+              {"token_sequence": "Shannon received his doctorate from MIT in 1940.",
+                "tag_sequence": "B-PER O O O O B-ORG O O"}
+            ]
+          },
+          {
+            "class": "BackTranslationNER",
+            "inputs": {"token_sequence": "Facebook announced that it would combat fake news by using fact checkers from sites like FactCheck.org and Associated Press.",
+            "tag_sequence": "B-ORG O O O O O O O O O O O O O O B-WEBSITE O B-WEBSITE I-WEBSITE"},
+            "outputs": [
+              {"token_sequence": "Facebook announced that it would fight fake news by providing fact-checkers from sites such as FactCheck.org and Associated Press.",
+                "tag_sequence": "B-ORG O O O O O O O O O O O O O O B-WEBSITE O B-WEBSITE I-WEBSITE"}
+            ]
+          }
+      ]
+    }

--- a/transformations/back_translation_ner/transformation.py
+++ b/transformations/back_translation_ner/transformation.py
@@ -10,6 +10,7 @@ from tasks.TaskTypes import TaskType
 
 class BackTranslationNER(TaggingOperation):
     tasks = [TaskType.TEXT_TAGGING]
+    heavy = True
     keywords = [
         "lexical",
         "model-based",

--- a/transformations/back_translation_ner/transformation.py
+++ b/transformations/back_translation_ner/transformation.py
@@ -10,6 +10,14 @@ from tasks.TaskTypes import TaskType
 
 class BackTranslationNER(TaggingOperation):
     tasks = [TaskType.TEXT_TAGGING]
+    keywords = [
+        "lexical",
+        "model-based",
+        "transformer-based",
+        "possible-meaning-alteration",
+        "high-generations",
+        "world-knowledge",
+    ]
 
     def __init__(self, segment_length=3, p=1.0, seed=0, max_outputs=1):
         super().__init__(seed, max_outputs=max_outputs)

--- a/transformations/back_translation_ner/transformation.py
+++ b/transformations/back_translation_ner/transformation.py
@@ -1,0 +1,122 @@
+import itertools
+from typing import List
+
+import numpy as np
+from transformers import FSMTForConditionalGeneration, FSMTTokenizer
+
+from interfaces.TaggingOperation import TaggingOperation
+from tasks.TaskTypes import TaskType
+
+
+class BackTranslationNER(TaggingOperation):
+    tasks = [TaskType.TEXT_TAGGING]
+
+    def __init__(self, segment_length=3, p=1.0, seed=0, max_outputs=1):
+        super().__init__(seed, max_outputs=max_outputs)
+        np.random.seed(seed)
+        self.segment_length = segment_length
+        self.p = p
+        self.max_outputs = max_outputs
+        mname_en2de = "facebook/wmt19-en-de"
+        mname_de2en = "facebook/wmt19-de-en"
+        self.tokenizer_en2de = FSMTTokenizer.from_pretrained(mname_en2de)
+        self.tokenizer_de2en = FSMTTokenizer.from_pretrained(mname_de2en)
+        self.model_en2de = FSMTForConditionalGeneration.from_pretrained(
+            mname_en2de
+        )
+        self.model_de2en = FSMTForConditionalGeneration.from_pretrained(
+            mname_de2en
+        )
+
+    def generate(self, token_sequence: List[str], tag_sequence: List[str]):
+        assert len(token_sequence) == len(
+            tag_sequence
+        ), f"token_sequence and tag_sequence should have same length! {len(token_sequence)}!={len(tag_sequence)}"
+        augmentations = []
+        segment_tokens, segment_tags = BackTranslationNER.create_segments(
+            token_sequence, tag_sequence
+        )
+        for _ in range(self.max_outputs):
+            tokens, tags = [], []
+            for s_token, s_tag in zip(segment_tokens, segment_tags):
+                translate_segment = np.random.binomial(1, p=self.p)
+                if (
+                    s_tag[0] != "O"
+                    or len(s_token) < self.segment_length
+                    or not translate_segment
+                ):
+                    tokens.extend(s_token)
+                    tags.extend(s_tag)
+                    continue
+                segment_text = " ".join(s_token)
+                segment_translation = self.translation_pipeline(segment_text)
+                translated_tokens = segment_translation.split()
+                translated_tags = ["O"] * len(translated_tokens)
+                tokens.extend(translated_tokens)
+                tags.extend(translated_tags)
+
+            augmentations.append(([tokens, tags]))
+
+        return augmentations
+
+    def translation_pipeline(self, text):
+        """
+        Pass the text in source languages through the intermediate
+        translations.
+        :param text: the text to translate
+        :return text_trans: backtranslated text
+        """
+        en2de_inputids = self.tokenizer_en2de.encode(text, return_tensors="pt")
+        outputs_en2de = self.model_en2de.generate(en2de_inputids)
+        text_trans = self.tokenizer_en2de.decode(
+            outputs_en2de[0], skip_special_tokens=True
+        )
+        de2en_inputids = self.tokenizer_de2en.encode(
+            text_trans, return_tensors="pt"
+        )
+        outputs_de2en = self.model_de2en.generate(de2en_inputids)
+        text_trans = self.tokenizer_en2de.decode(
+            outputs_de2en[0], skip_special_tokens=True
+        )
+        return text_trans
+
+    @staticmethod
+    def create_segments(tokens, tags):
+        """
+        A segment is defined as a consecutive sequence of same tag/label.
+        """
+        segment_tokens, segment_tags = [], []
+        tags_idxs = [(i, t) for i, t in enumerate(tags)]
+        groups = [
+            list(g)
+            for _, g in itertools.groupby(
+                tags_idxs, lambda s: s[1].split("-")[-1]
+            )
+        ]
+        for group in groups:
+            idxs = [i[0] for i in group]
+            segment_tokens.append([tokens[idx] for idx in idxs])
+            segment_tags.append([tags[idx] for idx in idxs])
+
+        return segment_tokens, segment_tags
+
+
+"""
+# Sample code to demonstrate usage.
+
+if __name__ == "__main__":
+
+    token_sequences = [
+        ["Musk", "has", "been", "the", "subject", "of", "criticism", "due", "to", "unorthodox", "or", "unscientific", "stances", "and", "highly", "publicized", "controversies", "."],
+        ["Shannon", "received", "his", "PhD", "from", "MIT", "in", "1940", "."]
+    ]
+    tag_sequences = [
+        ["B-PER", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O", "O"],
+        ["B-PER", "O", "O", "O", "O", "B-ORG", "O", "O", "O"]
+    ]
+
+    tf = BackTranslationNER()
+    augmentations = []
+    for token_sequence, tag_sequence in zip(token_sequences, tag_sequences):
+        augmentations.append(tf.generate(token_sequence, tag_sequence))
+"""


### PR DESCRIPTION
This transformation adapts backtranslation to the task of NER by generating paraphrases of the contexts around the entity mention(s) using backtranslation. It can be used as a data augmentation strategy to improve the underlying sequence (NER) model as reported by [Yaseen and Langer, 2021](https://arxiv.org/abs/2108.11703).

Contributors: Usama Yaseen (usama.yaseen@siemens.com), Stefan Langer (langer.stefan@siemens.com)

Affiliation: Siemens AG

