### PR TITLE
Special casing Filter

### DIFF
--- a/filters/special_casing/README.md
+++ b/filters/special_casing/README.md
@@ -15,6 +15,7 @@ This filter can be used to create splits of specially cased sentences of 3 types
 The proposed filter is quite simple. Related work in handling cases explicitly in neural models includes the work on factored segmenter [1] and Truecasing [2].
 
 [1] https://github.com/microsoft/factored-segmenter
+
 [2] https://arxiv.org/abs/2108.11943v1
 
 ## What are the limitations of this filter?

--- a/filters/special_casing/README.md
+++ b/filters/special_casing/README.md
@@ -1,0 +1,21 @@
+## Special Casing filter
+
+## What type of a filter is this?
+
+This filter checks if the input sentence has a special casing, i.e. the string is either all lowercased, all uppercased or has title casing.
+Author: Vikas Raunak (viraunak@microsoft.com)
+
+## Why is measuring performance on this split important?
+Traditionally, neural models are trained without any explicit casing information provided to the tokenizer. The most widely used data-driven tokenization algorithms, such as sentencepiece (Unigram LM) or Byte-Pair-Encoding typically do not have any explicit factors to handle casing information. Therefore, tackling edge cases pertaining to case is important in text generation problems, e.g. in Machine Translation if a newspaper headline in title casing is provided to the model, the general expectation is that the output should preseve this title case. Same is true for inputs which are fully uppercased (typical in ALERT messages) or fully lowercased (typical in chat messages).
+
+This filter can be used to create splits of specially cased sentences of 3 types, fully uppercased, fully lowercased or titlecased. Filtering out and testing on examples belonging to such special cased inputs can provide feedback for improving the model or guiding data augmentation accordingly.
+
+## Related Work
+
+The proposed filter is quite simple. Related work in handling cases explicitly in neural models includes the work on factored segmenter [1] and Truecasing [2].
+
+[1] https://github.com/microsoft/factored-segmenter
+[2] https://arxiv.org/abs/2108.11943v1
+
+## What are the limitations of this filter?
+Only three types of casing have been designated as special. I am not aware of other special casing types, but the proposed filter can be extended easily to increase coverage of such casing types.

--- a/filters/special_casing/README.md
+++ b/filters/special_casing/README.md
@@ -3,6 +3,7 @@
 ## What type of a filter is this?
 
 This filter checks if the input sentence has a special casing, i.e. the string is either all lowercased, all uppercased or has title casing.
+
 Author: Vikas Raunak (viraunak@microsoft.com)
 
 ## Why is measuring performance on this split important?

--- a/filters/special_casing/__init__.py
+++ b/filters/special_casing/__init__.py
@@ -1,0 +1,1 @@
+from .filter import *

--- a/filters/special_casing/filter.py
+++ b/filters/special_casing/filter.py
@@ -1,0 +1,20 @@
+from interfaces.SentenceOperation import SentenceOperation
+from tasks.TaskTypes import TaskType
+
+
+class TextSpecialCasingFilter(SentenceOperation):
+    """Filter if any of the special casings appear in the sentence:
+    All text is capitalized or All text is lowercased or there is Title Casing in the Sentence.
+    """
+
+    tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION]
+    languages = ["en"]
+
+    def __init__(self):
+        super().__init__()
+
+    def filter(self, sentence: str = None) -> bool:
+
+        return any(
+            [sentence.isupper(), sentence.islower(), sentence.istitle()]
+        )

--- a/filters/special_casing/filter.py
+++ b/filters/special_casing/filter.py
@@ -8,7 +8,8 @@ class TextSpecialCasingFilter(SentenceOperation):
     """
 
     tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION, TaskType.TEXT_TAGGING, TaskType.QUESTION_ANSWERING, TaskType.QUESTION_GENERATION, TaskType.SENTIMENT_ANALYSIS]
-    languages = ["en"]
+    languages = ["en", "fr", "es", "it", "pt", "fi", "nl", "da", "cs", "hr", "bg", "be", "eu", "ru", "uk", "pl", "sv", "sk", "sl"]
+    keywords = ["casing", "uppercase", "lowercase", "titlecase", "Latin", "Cyrillic"]
 
     def __init__(self):
         super().__init__()

--- a/filters/special_casing/filter.py
+++ b/filters/special_casing/filter.py
@@ -7,7 +7,7 @@ class TextSpecialCasingFilter(SentenceOperation):
     All text is capitalized or All text is lowercased or there is Title Casing in the Sentence.
     """
 
-    tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION]
+    tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION, TaskType.TEXT_TAGGING, TaskType.QUESTION_ANSWERING, TaskType.QUESTION_GENERATION, TaskType.SENTIMENT_ANALYSIS]
     languages = ["en"]
 
     def __init__(self):

--- a/filters/special_casing/test.json
+++ b/filters/special_casing/test.json
@@ -1,0 +1,62 @@
+{
+    "type": "keywords",
+    "test_cases": [
+        {
+            "class": "TextSpecialCasingFilter",
+
+            "inputs": {
+                "sentence": "let's go to chipotle"
+            },
+            "outputs": true
+        },
+        {
+            "class": "TextSpecialCasingFilter",
+
+            "inputs": {
+                "sentence": "AMBER ALERT: 4-YEAR OLD MISSING"
+            },
+            "outputs": true
+        },
+        {
+            "class": "TextSpecialCasingFilter",
+
+            "inputs": {
+                "sentence": "American Troops Withdraw From Afghanistan"
+            },
+            "outputs": true
+        },
+        {
+            "class": "TextSpecialCasingFilter",
+
+            "inputs": {
+                "sentence": "It has been brought to my notice that bread has gluten in it."
+            },
+            "outputs": false
+        },
+        {
+            "class": "TextSpecialCasingFilter",
+
+            "inputs": {
+                "sentence": "Leo Tolstoy wrote a very long book."
+            },
+            "outputs": false
+        },
+        {
+            "class": "TextSpecialCasingFilter",
+
+            "inputs": {
+                "sentence": "American Sniper was based on a real story."
+            },
+            "outputs": false
+        },
+        {
+            "class": "TextSpecialCasingFilter",
+
+            "inputs": {
+                "sentence": "One can become addicted to sugar, and sugary foods as well."
+            },
+            "outputs": false
+        }
+
+    ]
+}


### PR DESCRIPTION
This filter checks if the input sentence has a special casing, i.e. the string is either all lowercased, all uppercased or has title casing.

Traditionally, neural models are trained without any explicit casing information provided by the tokenizer. The most widely used data-driven tokenization algorithms, such as sentencepiece (Unigram LM) or Byte-Pair-Encoding typically do not have any explicit factors to handle case information. Therefore, tackling edge cases pertaining to case is important in text generation problems, e.g. in Machine Translation if a newspaper headline in title casing is provided to the model, the general expectation is that the output should preseve this title case. Same is true for inputs which are fully uppercased (typical in ALERT messages) or fully lowercased (typical in chat messages or asr transcripts).

This filter can be used to create splits of specially cased sentences of 3 types, fully uppercased, fully lowercased or titlecased. Filtering out and testing on examples belonging to such special cased inputs can provide feedback for improving the model or guiding data augmentation accordingly.

The PR includes the context, test cases and related work. Thanks.