### PR TITLE
Adding Diacritic Filter

### DIFF
--- a/filters/diacritic_filter/README.md
+++ b/filters/diacritic_filter/README.md
@@ -1,0 +1,23 @@
+## Diacritics filter
+
+## What type of a filter is this?
+
+This filter checks whether any character in the sentence has a diacritic.
+
+From Merriam-Webster: Diacritics are marks placed above or below (or sometimes next to) a letter in a word to indicate a particular pronunciation -- in regard to accent, tone, or stress — 
+as well as meaning, especially when a homograph exists without the marked letter or letters. For example, pâte refers to clay whereas pate refers to the head, 
+and résumé or resumé is used for a work history versus resume, which means "to begin again."
+
+Author: Vikas Raunak (viraunak@microsoft.com)
+
+## Why is measuring performance on this split important?
+Neural Sequence models have discrete vocabularies and commonly use subword segmentation techniques to achieve an ‘open vocabulary.’ [1] 
+This filter can be used to create splits of the dataet where the sentences have diacritics.
+Accented characters are typically among the rarer characters (& will likely result in different subword representations) and checking the model performance on such a split would be useful with respect to model robustness.
+
+## Related Work
+
+[1] Robust Open-Vocabulary Translation from Visual Text Representations https://arxiv.org/pdf/2104.08211.pdf
+
+## What are the limitations of this filter?
+For the intended purpose of filtering sentences with diacritics, it doesn't have any limitations (unless Python2 is used!).

--- a/filters/diacritic_filter/__init__.py
+++ b/filters/diacritic_filter/__init__.py
@@ -1,0 +1,1 @@
+from .filter import *

--- a/filters/diacritic_filter/filter.py
+++ b/filters/diacritic_filter/filter.py
@@ -1,0 +1,19 @@
+from interfaces.SentenceOperation import SentenceOperation
+from tasks.TaskTypes import TaskType
+import unicodedata
+
+class DiacriticFilter(SentenceOperation):
+
+    tasks = [TaskType.TEXT_CLASSIFICATION, TaskType.TEXT_TO_TEXT_GENERATION]
+    languages = ["en"]
+
+    def __init__(self):
+        super().__init__()
+
+    def strip_accents(self, sentence):
+
+        return str(unicodedata.normalize('NFD', sentence).encode('ascii', 'ignore').decode("utf-8"))
+
+    def filter(self, sentence: str = None) -> bool:
+
+        return sentence != self.strip_accents(sentence)

--- a/filters/diacritic_filter/test.json
+++ b/filters/diacritic_filter/test.json
@@ -1,0 +1,40 @@
+{
+    "type": "diacritic_filter",
+    "test_cases": [
+        {
+            "class": "DiacriticFilter",
+            "inputs": {
+                "sentence": "Feluda handed over the blue attaché case before he sat down."
+            },
+            "outputs": true
+        },
+        {
+            "class": "DiacriticFilter",
+            "inputs": {
+                "sentence": "She lookèd east an she lookèd west."
+            },
+            "outputs": true
+        },
+        {
+            "class": "DiacriticFilter",
+            "inputs": {
+                "sentence": "Karel Čapek was a Czech writer, playwright and critic."
+            },
+            "outputs": true
+        },
+        {
+            "class": "DiacriticFilter",
+            "inputs": {
+                "sentence": "HNO₃-oplossing"
+            },
+            "outputs": true
+        },
+        {
+            "class": "DiacriticFilter",
+            "inputs": {
+                "sentence": "Jonathan was a Seagull."
+            },
+            "outputs": false
+        }
+    ]
+}


### PR DESCRIPTION
This filter checks whether any character in the sentence has a diacritic.

Diacritics are marks placed above or below (or sometimes next to) a letter in a word to indicate a particular pronunciation -- in regard to accent, tone, or stress — as well as meaning, especially when a homograph exists without the marked letter or letters. For example, pâte refers to clay whereas pate refers to the head, and résumé or resumé is used for a work history versus resume, which means "to begin again."

Neural Sequence models have discrete vocabularies and commonly use subword segmentation techniques to achieve an ‘open vocabulary.’  This filter can be used to create splits of the dataset where the sentences have diacritics. Such accented characters are typically among the rarer characters (& will likely result in different subword representations) and checking the model performance on such a split would be useful with respect to model robustness.

This PR includes the test cases & references as well. Thanks.