### PR TITLE
NER evaluation -> Fixing the index of the return value of `generate(..)`

### DIFF
--- a/evaluation/evaluate_ner_tagging.py
+++ b/evaluation/evaluate_ner_tagging.py
@@ -106,7 +106,7 @@ def evaluate(
             # TODO: Needs to handle for multiple outputs.
             trans_input, trans_gold_tag_seq = operation.generate(
                 example["tokens"], gold_tag_seq
-            )
+            )[0]
             trans_gold_tag_seq = convert_ner_ids_to_tags(trans_gold_tag_seq)
             transformed_input_prediction = tagging_pipeline(trans_input)
             trans_predicted_tag_seq = create_prediction_seq(


### PR DESCRIPTION
The `generate(..)` function of (NER) transformations ([1], [2], [3] etc.) returns a list of perturbed `tokens` and `tags` tuples and the current implementation wrongly expects a tuple of `tokens` and `tags`. This PR just indexes the return value of `generate(..)` to enable computing "Robustness evaluation" numbers for NER transformations.
Just a side note, it would be better to report `strict` and `relaxed` F1-score as an evaluation metric for NER transformations.

[1] [longer_location_ner](https://github.com/GEM-benchmark/NL-Augmenter/blob/main/transformations/longer_location_ner/transformation.py#L130)
[2] [change_two_way_ner](https://github.com/GEM-benchmark/NL-Augmenter/blob/main/transformations/change_two_way_ne/transformation.py#L93)
[3] [entity_mention_replacement_ner](https://github.com/GEM-benchmark/NL-Augmenter/blob/main/transformations/entity_mention_replacement_ner/transformation.py#L86)