### PR TITLE
Fix pytest invalid escape sequence warnings using raw strings

### DIFF
--- a/transformations/country_state_abbreviation_transformation/transformation.py
+++ b/transformations/country_state_abbreviation_transformation/transformation.py
@@ -92,9 +92,9 @@ class CountryStateAbbreviation(SentenceOperation):
         # eg. country_pattern = '...|United States|...|USA|...'
         country_pattern = '|'.join(country_mapping.keys())
         # Adding backslash before '(' and ')' in country name as the escape character (eg. Virgin Islands (US))
-        country_pattern = country_pattern.replace('(', '\(')
-        country_pattern = country_pattern.replace(')', '\)')
-        country_regex = re.compile("(^|\s+)(" + country_pattern + ")(\s+|\?|!|$|\.|,)")
+        country_pattern = country_pattern.replace('(', r'\(')
+        country_pattern = country_pattern.replace(')', r'\)')
+        country_regex = re.compile(r"(^|\s+)(" + country_pattern + r")(\s+|\?|!|$|\.|,)")
         perturbed_text = country_regex.sub(
             lambda y: y[1] + country_mapping[y[2]] + y[3],
             text,
@@ -104,9 +104,9 @@ class CountryStateAbbreviation(SentenceOperation):
         # eg. state_pattern = '...|Pennsylvania|...|PA|...'
         state_pattern = '|'.join(state_mapping.keys())
         # Adding backslash before '(' and ')' in state name as the escape character
-        state_pattern = state_pattern.replace('(', '\(')
-        state_pattern = state_pattern.replace(')', '\)')
-        state_regex = re.compile("(^|\s+)(" + state_pattern + ")(\s+|\?|!|$|\.|,)")
+        state_pattern = state_pattern.replace('(', r'\(')
+        state_pattern = state_pattern.replace(')', r'\)')
+        state_regex = re.compile(r"(^|\s+)(" + state_pattern + r")(\s+|\?|!|$|\.|,)")
         perturbed_text = state_regex.sub(
             lambda y: y[1] + self.dict_value_helper(state_mapping, y[2]) + y[3],
             perturbed_text,

--- a/transformations/greetings_and_farewells/transformation.py
+++ b/transformations/greetings_and_farewells/transformation.py
@@ -57,9 +57,9 @@ SPECIAL_GREETINGS_REGEX = (
         "(it('s| is| was) |)(a |)(nice|great|pleased|pleasure) to meet (you|u)(.|)",
         re.IGNORECASE,
     ),
-    re.compile("how( are|'re|) (you|u) doin(g|'|)\?", re.IGNORECASE),
-    re.compile("how( is|'s|) it going( on|)\?", re.IGNORECASE),
-    re.compile("how( have|'ve|) you been\?", re.IGNORECASE),
+    re.compile(r"how( are|'re|) (you|u) doin(g|'|)\?", re.IGNORECASE),
+    re.compile(r"how( is|'s|) it going( on|)\?", re.IGNORECASE),
+    re.compile(r"how( have|'ve|) you been\?", re.IGNORECASE),
 )
 
 FAREWELLS_REGEX = (


### PR DESCRIPTION
Fixes pytest warnings.  pytest currently outputs:
```
=============================== warnings summary ===============================
test/test_main.py::test_operation[light-light]
  /home/runner/work/NL-Augmenter/NL-Augmenter/transformations/country_state_abbreviation_transformation/transformation.py:95: DeprecationWarning: invalid escape sequence \(
    country_pattern = country_pattern.replace('(', '\(')

test/test_main.py::test_operation[light-light]
  /home/runner/work/NL-Augmenter/NL-Augmenter/transformations/country_state_abbreviation_transformation/transformation.py:96: DeprecationWarning: invalid escape sequence \)
    country_pattern = country_pattern.replace(')', '\)')

test/test_main.py::test_operation[light-light]
test/test_main.py::test_operation[light-light]
  /home/runner/work/NL-Augmenter/NL-Augmenter/transformations/country_state_abbreviation_transformation/transformation.py:97: DeprecationWarning: invalid escape sequence \s
    country_regex = re.compile("(^|\s+)(" + country_pattern + ")(\s+|\?|!|$|\.|,)")

test/test_main.py::test_operation[light-light]
  /home/runner/work/NL-Augmenter/NL-Augmenter/transformations/country_state_abbreviation_transformation/transformation.py:107: DeprecationWarning: invalid escape sequence \(
    state_pattern = state_pattern.replace('(', '\(')

test/test_main.py::test_operation[light-light]
  /home/runner/work/NL-Augmenter/NL-Augmenter/transformations/country_state_abbreviation_transformation/transformation.py:108: DeprecationWarning: invalid escape sequence \)
    state_pattern = state_pattern.replace(')', '\)')

test/test_main.py::test_operation[light-light]
test/test_main.py::test_operation[light-light]
  /home/runner/work/NL-Augmenter/NL-Augmenter/transformations/country_state_abbreviation_transformation/transformation.py:109: DeprecationWarning: invalid escape sequence \s
    state_regex = re.compile("(^|\s+)(" + state_pattern + ")(\s+|\?|!|$|\.|,)")

test/test_main.py::test_operation[light-light]
  /home/runner/work/NL-Augmenter/NL-Augmenter/transformations/greetings_and_farewells/transformation.py:60: DeprecationWarning: invalid escape sequence \?
    re.compile("how( are|'re|) (you|u) doin(g|'|)\?", re.IGNORECASE),

test/test_main.py::test_operation[light-light]
  /home/runner/work/NL-Augmenter/NL-Augmenter/transformations/greetings_and_farewells/transformation.py:61: DeprecationWarning: invalid escape sequence \?
    re.compile("how( is|'s|) it going( on|)\?", re.IGNORECASE),

test/test_main.py::test_operation[light-light]
  /home/runner/work/NL-Augmenter/NL-Augmenter/transformations/greetings_and_farewells/transformation.py:62: DeprecationWarning: invalid escape sequence \?
    re.compile("how( have|'ve|) you been\?", re.IGNORECASE),

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================== 1 passed, 11 warnings in 116.26s (0:01:56) ==================
```