### PR TITLE
fix dataset issue: no. of datapoints to be equal to the number of lab…

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -101,21 +101,25 @@ class TextLineDataset(BaseDataset):
         self, transformation: SentenceOperation
     ) -> TextLineDataset:
         transformed_data = []
+        transformed_labels = []
         print("Applying transformation:")
 
         # calculating ratio of transformed example to unchanged example
         successful_num = 0
         failed_num = 0
 
-        for line in tqdm(self.data):
-            pt_examples = transformation.generate(line)
+        for datapoint, label in tqdm(
+            zip(self.data, self.labels), total=len(self.data)
+        ):
+            pt_examples = transformation.generate(datapoint)
             successful_pt, failed_pt = transformation.compare(
-                line, pt_examples
+                datapoint, pt_examples
             )
             successful_num += successful_pt
             failed_num += failed_pt
 
             transformed_data.extend(pt_examples)
+            transformed_labels.extend([label]*len(pt_examples))
 
         total_num = successful_num + failed_num
         print(
@@ -129,7 +133,7 @@ class TextLineDataset(BaseDataset):
         )
         if total_num == 0:
             return None
-        return TextLineDataset(transformed_data, self.labels)
+        return TextLineDataset(transformed_data, transformed_labels)
 
     def __iter__(self):
         for text, label in zip(self.data, self.labels):


### PR DESCRIPTION
Fixing error when evaluating GeoNamesTransformation.
```
Traceback (most recent call last):
  File "evaluate.py", line 71, in <module>
    if_filter,
  File "/content/NL-Augmenter/evaluation/evaluation_engine.py", line 43, in evaluate
    percentage_of_examples=percentage_of_examples,
  File "/content/NL-Augmenter/evaluation/evaluation_engine.py", line 93, in execute_model
    split=f"test[:{percentage_of_examples}%]",
  File "/content/NL-Augmenter/evaluation/evaluate_text_classification.py", line 141, in evaluate
    pt_dataset = dataset.apply_transformation(operation)
  File "/content/NL-Augmenter/dataset.py", line 132, in apply_transformation
    return TextLineDataset(transformed_data, self.labels)
  File "/content/NL-Augmenter/dataset.py", line 70, in __init__
    ), "The number of datapoint should be the same as the number of labels"
AssertionError: The number of datapoint should be the same as the number of labels
```

The issue was caused because the transformation generated multiple outputs but the `TextLineDataset` was not updated and assumed only one output is generated.