### PR TITLE
Added default argument for instantiating ToxicityFilter class

### DIFF
--- a/filters/toxicity/filter.py
+++ b/filters/toxicity/filter.py
@@ -24,7 +24,7 @@ class ToxicityFilter(SentenceOperation):
 
     def __init__(
         self,
-        toxicity_type: ToxicityTypes,
+        toxicity_type: ToxicityTypes = ToxicityTypes.TOXICITY,
         op: str = ">",
         threshold: float = 0.5,
     ):


### PR DESCRIPTION
Added a default argument to enable the instantiation of the `ToxicityFilter` class without providing any arguments. This was required because the evaluation interface for robustness lacks the option of providing custom options for instantiating classes.