### PR TITLE
Updated installation options for NL-Augmenter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,22 @@ def get_extra_requirements() -> dict:
     from the generated dictionary will be picked up and installed along with the default
     requiremens.
 
+    The generated dictionary will be of this format:
+    {
+        'lost_in_translation': ['rouge_score'],
+        'mr_value_replacement': ['torchtext==0.9.1'],
+        'ocr_perturbation': ['trdg==1.6.0', 'tesserocr>=2.5.2'],
+        'pinyin': ['g2pM==0.1.2.5'],
+        'punctuation': ['cucco==2.2.1', 'fastpunct==2.0.2'],
+        'sentence_reordering': ['allennlp==2.5.0', 'allennlp-models==2.5.0'],
+        'synonym_substitution': ['nltk==3.6.2'],
+        'token_replacement': ['editdistance>=0.5.3'],
+        'transformer_fill': ['torch', 'transformers', 'spacy'],
+        'toxicity': ['detoxify==0.2.2']
+    }
+
+    Example usage: pip install NL-Augmenter[lost_in_translation]
+
     Returns:
     -------
     dict
@@ -113,18 +129,22 @@ def get_extra_requirements() -> dict:
     """
     # Dictionary of requirements
     requirements = {}
+    count = 0
     # Heavy transformations picked from test/mapper.py
     for entry in map_transformation["heavy"]:
         file_name = "transformations/" + entry + "/requirements.txt"
         if os.path.exists(file_name):
             req_string = read(file_name)
             requirements[entry] = filter_requirements(req_string)
+            count += 1
     # Heavy filters picked from test/mapper.py
     for entry in map_filter["heavy"]:
         file_name = "filters/" + entry + "/requirements.txt"
         if os.path.exists(file_name):
             req_string = read(file_name)
             requirements[entry] = filter_requirements(req_string)
+            count += 1
+    print(count)
     return requirements
 
 

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,26 @@ def get_default_requirements(transformation_type: str) -> list:
     return mandatory_requirements
 
 
+def filter_requirements(requirements: str) -> list:
+    """Filter the requirements, exclude comments, empty strings
+
+    Parameters:
+    -----------
+    requirements: str,
+        string of requirements
+
+    Returns:
+    --------
+    list
+        list of filtered requirements
+    """
+    list_requirements = requirements.split("\n")
+    for entry in list_requirements:
+        if "#" in entry or entry == "":
+            list_requirements.remove(entry)
+    return list_requirements
+
+
 def get_extra_requirements() -> dict:
     """
     Get the dict of requirements for all the heavy transformations and filters.
@@ -95,14 +115,16 @@ def get_extra_requirements() -> dict:
     requirements = {}
     # Heavy transformations picked from test/mapper.py
     for entry in map_transformation["heavy"]:
-        requirements[entry] = recursive_requirements(
-            "transformations/" + entry, "heavy"
-        )
+        file_name = "transformations/" + entry + "/requirements.txt"
+        if os.path.exists(file_name):
+            req_string = read(file_name)
+            requirements[entry] = filter_requirements(req_string)
     # Heavy filters picked from test/mapper.py
     for entry in map_filter["heavy"]:
-        requirements[entry] = recursive_requirements(
-            "filters/" + entry, "heavy"
-        )
+        file_name = "filters/" + entry + "/requirements.txt"
+        if os.path.exists(file_name):
+            req_string = read(file_name)
+            requirements[entry] = filter_requirements(req_string)
     return requirements
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 import os
+from test.mapper import map_filter, map_transformation
 
 from setuptools import setup
 
 from TestRunner import OperationRuns
-from test.mapper import map_transformation, map_filter
+
 
 def all_folders(search: str, transformation_type: str) -> list:
     """
@@ -27,12 +28,6 @@ def all_folders(search: str, transformation_type: str) -> list:
             OperationRuns.get_all_folder_names(search, transformation_type)
         )
     ]
-    #folder_names.extend(
-    #    [
-    #        "filters/" + f
-    #        for f in list(OperationRuns.get_all_folder_names("filters"))
-    #    ]
-    #)
     return folder_names
 
 
@@ -56,9 +51,9 @@ def recursive_requirements(search: str, transformation_type: str) -> str:
 
 
 def get_default_requirements(transformation_type: str) -> list:
-    """ 
+    """
     Populate the default requirements to be installed for the library
-        
+
     Parameters
     ----------
     transformation_type: str,
@@ -73,10 +68,15 @@ def get_default_requirements(transformation_type: str) -> list:
     # (1) read main requirements.txt
     mandatory_requirements = read("requirements.txt")
     # (2) read requirements for light transformations
-    mandatory_requirements += recursive_requirements("transformations", "light")
+    mandatory_requirements += recursive_requirements(
+        "transformations", "light"
+    )
     # (3) read requirements for light filters
-    mandatory_requirements += recursive_requirements("filters", "light") # light filters
+    mandatory_requirements += recursive_requirements(
+        "filters", "light"
+    )  # light filters
     return mandatory_requirements
+
 
 def get_extra_requirements() -> dict:
     """
@@ -95,11 +95,16 @@ def get_extra_requirements() -> dict:
     requirements = {}
     # Heavy transformations picked from test/mapper.py
     for entry in map_transformation["heavy"]:
-        requirements[entry] = recursive_requirements("transformations/" + entry, "heavy")
+        requirements[entry] = recursive_requirements(
+            "transformations/" + entry, "heavy"
+        )
     # Heavy filters picked from test/mapper.py
     for entry in map_filter["heavy"]:
-        requirements[entry] = recursive_requirements("filters/" + entry, "heavy")
+        requirements[entry] = recursive_requirements(
+            "filters/" + entry, "heavy"
+        )
     return requirements
+
 
 setup(
     name="NL-Augmenter",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from setuptools import setup
 
 from TestRunner import OperationRuns
-
+from test.mapper import map_transformation, map_filter
 
 def all_folders(search: str, transformation_type: str) -> list:
     """
@@ -22,17 +22,17 @@ def all_folders(search: str, transformation_type: str) -> list:
 
     """
     folder_names = [
-        "transformations/" + f
+        search + "/" + f
         for f in list(
             OperationRuns.get_all_folder_names(search, transformation_type)
         )
     ]
-    folder_names.extend(
-        [
-            "filters/" + f
-            for f in list(OperationRuns.get_all_folder_names("filters"))
-        ]
-    )
+    #folder_names.extend(
+    #    [
+    #        "filters/" + f
+    #        for f in list(OperationRuns.get_all_folder_names("filters"))
+    #    ]
+    #)
     return folder_names
 
 
@@ -43,10 +43,8 @@ def read(fname):
 
 
 def recursive_requirements(search: str, transformation_type: str) -> str:
-    # (1) read main requirements.txt
-    requirements = read("requirements.txt")
-
     # (1) read all requirements.txt in the folder.
+    requirements = ""
     for folder in all_folders(search, transformation_type):
         r_file = os.path.join(
             os.path.dirname(__file__), folder + "/requirements.txt"
@@ -57,14 +55,59 @@ def recursive_requirements(search: str, transformation_type: str) -> str:
     return requirements
 
 
+def get_default_requirements(transformation_type: str) -> list:
+    """ 
+    Populate the default requirements to be installed for the library
+        
+    Parameters
+    ----------
+    transformation_type: str,
+        type of transformation, light or heavy.
+
+    Returns:
+    -------
+    list
+        list of requirements.
+    """
+    # Get the default requirements (light transformations and light filters)
+    # (1) read main requirements.txt
+    mandatory_requirements = read("requirements.txt")
+    # (2) read requirements for light transformations
+    mandatory_requirements += recursive_requirements("transformations", "light")
+    # (3) read requirements for light filters
+    mandatory_requirements += recursive_requirements("filters", "light") # light filters
+    return mandatory_requirements
+
+def get_extra_requirements() -> dict:
+    """
+    Get the dict of requirements for all the heavy transformations and filters.
+    If a user specifies a heavy transformation or filter, the corresponding requirements
+    from the generated dictionary will be picked up and installed along with the default
+    requiremens.
+
+    Returns:
+    -------
+    dict
+        dict of requirements for all the heavy transformations and filters.
+
+    """
+    # Dictionary of requirements
+    requirements = {}
+    # Heavy transformations picked from test/mapper.py
+    for entry in map_transformation["heavy"]:
+        requirements[entry] = recursive_requirements("transformations/" + entry, "heavy")
+    # Heavy filters picked from test/mapper.py
+    for entry in map_filter["heavy"]:
+        requirements[entry] = recursive_requirements("filters/" + entry, "heavy")
+    return requirements
+
 setup(
     name="NL-Augmenter",
     version="0.0.1",
     description="The official repository of transformations.",
     long_description=read("README.md"),
-    install_requires=recursive_requirements(
-        "transformations", "light"
-    ),  # read("requirements.txt") for light transformations and all filters
+    install_requires=get_default_requirements("light"),
+    extras_require=get_extra_requirements(),
     package_data={
         "": ["*.json", "*.txt", "*.tsv", "*.csv", "*.npz", "*.ckpt"]
     },


### PR DESCRIPTION
As part of this PR, the following are done
- Added default installation option (all light transformations and filters and common requirements will be installed by default)
- Added options to install individual heavy transformations/filters using pip install once the packaging is done. 

Usage:
```python
pip install NL-Augmenter[toxicity]
```
- Next step is to build and upload the package to pypi [will be added as a separate PR]